### PR TITLE
Fix sample agent output

### DIFF
--- a/examples/realtime/cli/demo.py
+++ b/examples/realtime/cli/demo.py
@@ -52,7 +52,7 @@ class NoUIDemo:
         # Audio output state for callback system
         self.output_queue: queue.Queue[Any] = queue.Queue(maxsize=10)  # Buffer more chunks
         self.interrupt_event = threading.Event()
-        self.current_audio_chunk: np.ndarray | None = None  # type: ignore
+        self.current_audio_chunk: np.ndarray | None = None
         self.chunk_position = 0
 
     def _output_callback(self, outdata, frames: int, time, status) -> None:

--- a/twin_generator.py
+++ b/twin_generator.py
@@ -228,7 +228,8 @@ SampleAgent = Agent(
     name="sample",
     instructions=(
         "Given a parameterized math problem template, generate a candidate "
-        "parameter set and compute output."
+        "parameter set and compute output. "
+        "Return only the parameter mapping as valid JSON without any prose."
     ),
     model="gpt-4o",
 )


### PR DESCRIPTION
## Summary
- instruct sample agent to output plain JSON only
- remove unused mypy ignore in realtime example

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_687f3e7339ac8330b14181dab7ed505e