### PR TITLE
Add GraphSpec typed dict

### DIFF
--- a/twin_generator/constants.py
+++ b/twin_generator/constants.py
@@ -1,9 +1,19 @@
 """Package‑wide constants and demo assets."""
 
+from typing import TypedDict
+
+
+class GraphSpec(TypedDict):
+    """Dictionary describing a simple graph specification."""
+
+    points: list[list[float]]
+    style: str
+    title: str
+
 _DEMO_PROBLEM = """If 3x + 2 = 17, what is the value of x?"""
 _DEMO_SOLUTION = """Subtract 2 → 3x = 15, then divide by 3 → x = 5."""
 
-DEFAULT_GRAPH_SPEC: dict[str, list] = {
+DEFAULT_GRAPH_SPEC: GraphSpec = {
     "points": [[0, -1], [1, 1], [2, 3], [3, 5]],  # slope 2, intercept −1
     "style": "line",
     "title": "y = 2x − 1",
@@ -18,6 +28,7 @@ _GRAPH_SOLUTION = """Slope (m) = 2, y‑intercept = −1 → y = 2x − 1."""
 __all__ = [
     "_DEMO_PROBLEM",
     "_DEMO_SOLUTION",
+    "GraphSpec",
     "DEFAULT_GRAPH_SPEC",
     "_GRAPH_PROBLEM",
     "_GRAPH_SOLUTION",

--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, cast
 from agents.run import Runner as AgentsRunner  # type: ignore
 
 from . import constants as C
+from .constants import GraphSpec
 from .agents import (
     ConceptAgent,
     FormatterAgent,
@@ -180,7 +181,7 @@ def generate_twin(
     solution_text: str,
     *,
     force_graph: bool = False,
-    graph_spec: dict[str, Any] | None = None,
+    graph_spec: GraphSpec | None = None,
     verbose: bool = False,
 ) -> dict[str, Any]:  # noqa: ANN401 – generic return
     """Generate a twin SAT‑style math question given a source problem/solution."""


### PR DESCRIPTION
## Summary
- add a GraphSpec `TypedDict`
- use the new type for the default graph spec
- update pipeline to accept `GraphSpec` objects

## Testing
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6889c23d88a48330ba5dd779b476dd68