### PR TITLE
Lazy matplotlib import

### DIFF
--- a/twin_generator/tools.py
+++ b/twin_generator/tools.py
@@ -6,22 +6,8 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
-import matplotlib  # type: ignore
-import matplotlib.pyplot as plt  # type: ignore
-import numpy as np  # type: ignore
-from PIL import Image  # type: ignore
-
-# Prefer an interactive backend when a display is available; otherwise fall back
-_prefer_tk = os.environ.get("DISPLAY") or os.environ.get("MPLBACKEND") == "TkAgg"
-try:
-    if _prefer_tk:
-        matplotlib.use("TkAgg")
-    else:
-        matplotlib.use("Agg")
-except Exception:
-    matplotlib.use("Agg")
 
 from agents.tool import function_tool as tool  # type: ignore
 
@@ -59,6 +45,16 @@ make_html_table_tool = tool(_make_html_table)
 
 def _render_graph(spec_json: str) -> str:
     """Render a graph to a **PNG file** and return the file path (string)."""
+    import matplotlib  # type: ignore
+    _prefer_tk = os.environ.get("DISPLAY") or os.environ.get("MPLBACKEND") == "TkAgg"
+    try:
+        if _prefer_tk:
+            matplotlib.use("TkAgg")
+        else:
+            matplotlib.use("Agg")
+    except Exception:
+        matplotlib.use("Agg")
+    import matplotlib.pyplot as plt  # type: ignore
     spec = json.loads(spec_json)
     points: list[list[float]] = spec.get("points", [])
     style: str = spec.get("style", "line")


### PR DESCRIPTION
## Summary
- remove unused imports from tools
- defer matplotlib import inside the graph renderer

## Testing
- `python -m pip install -e .`
- `python - <<'EOF'
from twin_generator.tools import _render_graph
print('render_graph path', _render_graph('{"points": [[0,1],[2,3]], "style":"line"}'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6889c21cae888330a04726f56234a066