### PR TITLE
Improve agent error handling

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,60 @@
+import types
+from types import SimpleNamespace
+
+import pytest
+
+import twin_generator.pipeline as pipeline
+
+
+def test_generate_twin_success(monkeypatch):
+    calls = []
+
+    def mock_run_sync(agent, input):
+        calls.append(agent.name)
+        name = agent.name
+        if name == "ParserAgent":
+            return SimpleNamespace(final_output="parsed")
+        if name == "ConceptAgent":
+            return SimpleNamespace(final_output="concept")
+        if name == "TemplateAgent":
+            return SimpleNamespace(final_output='{"visual": {"type": "none"}, "answer_expression": "x"}')
+        if name == "SampleAgent":
+            return SimpleNamespace(final_output='{"x": 1}')
+        if name == "StemChoiceAgent":
+            return SimpleNamespace(final_output='{"twin_stem": "What is 1?", "choices": [1], "rationale": "r"}')
+        if name == "FormatterAgent":
+            return SimpleNamespace(final_output='{"twin_stem": "What is 1?", "choices": [1], "answer_index": 0, "answer_value": 1, "rationale": "r"}')
+        raise AssertionError("unexpected agent")
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    out = pipeline.generate_twin("p", "s")
+    assert out["twin_stem"] == "What is 1?"
+    assert out.get("errors") == []
+    assert calls == [
+        "ParserAgent",
+        "ConceptAgent",
+        "TemplateAgent",
+        "SampleAgent",
+        "StemChoiceAgent",
+        "FormatterAgent",
+    ]
+
+
+def test_generate_twin_agent_failure(monkeypatch):
+    call_order = []
+
+    def mock_run_sync(agent, input):
+        call_order.append(agent.name)
+        if len(call_order) == 3:
+            raise RuntimeError("boom")
+        return SimpleNamespace(final_output="ok")
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    out = pipeline.generate_twin("p", "s")
+    assert out.get("error") == "TemplateAgent failed: boom"
+    # ensure pipeline stopped early
+    assert call_order == ["ParserAgent", "ConceptAgent", "TemplateAgent"]
+    assert "params" not in out
+


### PR DESCRIPTION
## Summary
- stop pipeline execution when a step records an error
- wrap all `AgentsRunner.run_sync` calls in try/except
- return an error message on failure
- add tests covering success and failure scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c421ec888330ab8febb7f7b84074