### PR TITLE
Fix flake8 errors and add typing

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,15 +1,16 @@
-import types
+from __future__ import annotations
+
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
-
 import twin_generator.pipeline as pipeline
 
 
-def test_generate_twin_success(monkeypatch):
+def test_generate_twin_success(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = []
 
-    def mock_run_sync(agent, input):
+    def mock_run_sync(agent: Any, input: Any) -> SimpleNamespace:
         calls.append(agent.name)
         name = agent.name
         if name == "ParserAgent":
@@ -23,7 +24,12 @@ def test_generate_twin_success(monkeypatch):
         if name == "StemChoiceAgent":
             return SimpleNamespace(final_output='{"twin_stem": "What is 1?", "choices": [1], "rationale": "r"}')
         if name == "FormatterAgent":
-            return SimpleNamespace(final_output='{"twin_stem": "What is 1?", "choices": [1], "answer_index": 0, "answer_value": 1, "rationale": "r"}')
+            return SimpleNamespace(
+                final_output=(
+                    '{"twin_stem": "What is 1?", "choices": [1], '
+                    '"answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                )
+            )
         raise AssertionError("unexpected agent")
 
     monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
@@ -41,10 +47,10 @@ def test_generate_twin_success(monkeypatch):
     ]
 
 
-def test_generate_twin_agent_failure(monkeypatch):
+def test_generate_twin_agent_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     call_order = []
 
-    def mock_run_sync(agent, input):
+    def mock_run_sync(agent: Any, input: Any) -> SimpleNamespace:
         call_order.append(agent.name)
         if len(call_order) == 3:
             raise RuntimeError("boom")

--- a/twin_generator/constants.py
+++ b/twin_generator/constants.py
@@ -10,6 +10,7 @@ class GraphSpec(TypedDict):
     style: str
     title: str
 
+
 _DEMO_PROBLEM = """If 3x + 2 = 17, what is the value of x?"""
 _DEMO_SOLUTION = """Subtract 2 → 3x = 15, then divide by 3 → x = 5."""
 

--- a/twin_generator/tools.py
+++ b/twin_generator/tools.py
@@ -8,6 +8,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from agents.tool import function_tool
+
 __all__ = [
     "make_html_table_tool",
     "render_graph_tool",
@@ -33,7 +35,7 @@ def _make_html_table(table_json: str) -> str:
     return f"<table><thead><tr>{head_html}</tr></thead><tbody>{rows_html}</tbody></table>"
 
 
-make_html_table_tool = tool(_make_html_table)
+make_html_table_tool = function_tool(_make_html_table)
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +122,7 @@ def _render_graph(spec_json: str) -> str:
     return str(png_path)
 
 
-render_graph_tool = tool(_render_graph)
+render_graph_tool = function_tool(_render_graph)
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +137,7 @@ def _calc_answer(expression: str, params_json: str) -> Any:  # noqa: ANN401 â€“Â
     * Falls back to numeric evaluation
     * Coerces nearâ€‘integers to ``int`` when appropriate
     """
+    import sympy as sp
     params = json.loads(params_json)
     expr = sp.sympify(expression)
     exact = expr.subs(params)
@@ -166,4 +169,4 @@ def _calc_answer(expression: str, params_json: str) -> Any:  # noqa: ANN401 â€“Â
         return str(result)
 
 
-calc_answer_tool = tool(_calc_answer)
+calc_answer_tool = function_tool(_calc_answer)


### PR DESCRIPTION
## Summary
- satisfy flake8 style by adding a blank line in `constants.py`
- use `function_tool` from `agents.tool` and import `sympy` lazily
- add type hints in tests

## Testing
- `flake8`
- `mypy --config-file=mypy.ini twin_generator tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889c6de79a483308caf40a0cd223ba5