### PR TITLE
Add QA agent verification to pipeline

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,5 @@
+class Agent:
+    def __init__(self, name: str, instructions: str, model: str | None = None):
+        self.name = name
+        self.instructions = instructions
+        self.model = model

--- a/agents/run.py
+++ b/agents/run.py
@@ -1,4 +1,10 @@
+"""Runner interface for executing agents synchronously."""
+
+from typing import Any
+
+
 class Runner:
     @staticmethod
-    def run_sync(agent, input):
+    def run_sync(agent: Any, input: Any) -> Any:
+        """Execute the given agent with the provided input."""
         raise NotImplementedError

--- a/agents/run.py
+++ b/agents/run.py
@@ -1,0 +1,4 @@
+class Runner:
+    @staticmethod
+    def run_sync(agent, input):
+        raise NotImplementedError

--- a/agents/tool.py
+++ b/agents/tool.py
@@ -1,2 +1,11 @@
-def function_tool(func):
+"""Utilities for defining simple function-based tools."""
+
+from typing import Any, Callable, TypeVar
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def function_tool(func: F) -> F:
+    """Return the provided function as a tool with preserved type."""
     return func

--- a/agents/tool.py
+++ b/agents/tool.py
@@ -1,0 +1,2 @@
+def function_tool(func):
+    return func

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import pytest
 import twin_generator.pipeline as pipeline
 
@@ -30,6 +35,8 @@ def test_generate_twin_success(monkeypatch: pytest.MonkeyPatch) -> None:
                     '"answer_index": 0, "answer_value": 1, "rationale": "r"}'
                 )
             )
+        if name == "QAAgent":
+            return SimpleNamespace(final_output="pass")
         raise AssertionError("unexpected agent")
 
     monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
@@ -39,11 +46,19 @@ def test_generate_twin_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert out.get("errors") == []
     assert calls == [
         "ParserAgent",
+        "QAAgent",
         "ConceptAgent",
+        "QAAgent",
         "TemplateAgent",
+        "QAAgent",
         "SampleAgent",
+        "QAAgent",
+        "QAAgent",
+        "QAAgent",
         "StemChoiceAgent",
+        "QAAgent",
         "FormatterAgent",
+        "QAAgent",
     ]
 
 
@@ -52,7 +67,9 @@ def test_generate_twin_agent_failure(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def mock_run_sync(agent: Any, input: Any) -> SimpleNamespace:
         call_order.append(agent.name)
-        if len(call_order) == 3:
+        if agent.name == "QAAgent":
+            return SimpleNamespace(final_output="pass")
+        if agent.name == "TemplateAgent":
             raise RuntimeError("boom")
         return SimpleNamespace(final_output="ok")
 
@@ -61,6 +78,12 @@ def test_generate_twin_agent_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     out = pipeline.generate_twin("p", "s")
     assert out.get("error") == "TemplateAgent failed: boom"
     # ensure pipeline stopped early
-    assert call_order == ["ParserAgent", "ConceptAgent", "TemplateAgent"]
+    assert call_order == [
+        "ParserAgent",
+        "QAAgent",
+        "ConceptAgent",
+        "QAAgent",
+        "TemplateAgent",
+    ]
     assert "params" not in out
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,10 +6,11 @@ from typing import Any
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-import pytest
-import twin_generator.pipeline as pipeline
+import twin_generator.pipeline as pipeline  # noqa: E402
 
 
 def test_generate_twin_success(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -57,6 +57,15 @@ FormatterAgent = Agent(
     model="gpt-4o",
 )
 
+QAAgent = Agent(
+    name="QAAgent",
+    instructions=(
+        "Validate the previous step's output for correctness and internal consistency. "
+        "Return 'pass' if the output is sound, otherwise return a brief reason.",
+    ),
+    model="gpt-4o",
+)
+
 __all__ = [
     "ParserAgent",
     "ConceptAgent",
@@ -64,5 +73,6 @@ __all__ = [
     "SampleAgent",
     "StemChoiceAgent",
     "FormatterAgent",
+    "QAAgent",
 ]
 

--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -61,7 +61,7 @@ QAAgent = Agent(
     name="QAAgent",
     instructions=(
         "Validate the previous step's output for correctness and internal consistency. "
-        "Return 'pass' if the output is sound, otherwise return a brief reason.",
+        "Return 'pass' if the output is sound, otherwise return a brief reason."
     ),
     model="gpt-4o",
 )


### PR DESCRIPTION
## Summary
- Introduce QAAgent to validate each pipeline stage
- Run QA checks after every step with retry loop on failure
- Adjust tests and add stub agents package for pipeline execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e4abf41083309eeae349111a3fec