### PR TITLE
feat: add operation stages with branching

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -24,8 +24,20 @@ def test_generate_twin_success(monkeypatch: pytest.MonkeyPatch) -> None:
         if name == "ConceptAgent":
             return SimpleNamespace(final_output="concept")
         if name == "TemplateAgent":
-            return SimpleNamespace(final_output='{"visual": {"type": "none"}, "answer_expression": "x"}')
+            return SimpleNamespace(
+                final_output=(
+                    '{"visual": {"type": "none"}, "answer_expression": "x", '
+                    '"operations": ['
+                    '{"kind": "sympy", "expr": "1", "output": "run_agent"}, '
+                    '{"kind": "agent", "agent": "SampleAgent", '
+                    '"input_key": "run_agent", "output": "extra", '
+                    '"condition": "run_agent"}'
+                    ']}'
+                )
+            )
         if name == "SampleAgent":
+            if isinstance(input, int):
+                return SimpleNamespace(final_output="extra_done")
             return SimpleNamespace(final_output='{"x": 1}')
         if name == "StemChoiceAgent":
             return SimpleNamespace(final_output='{"twin_stem": "What is 1?", "choices": [1], "rationale": "r"}')
@@ -53,6 +65,12 @@ def test_generate_twin_success(monkeypatch: pytest.MonkeyPatch) -> None:
         "TemplateAgent",
         "QAAgent",
         "SampleAgent",
+        "QAAgent",
+        "QAAgent",
+        "QAAgent",
+        "SampleAgent",
+        "QAAgent",
+        "QAAgent",
         "QAAgent",
         "StemChoiceAgent",
         "QAAgent",


### PR DESCRIPTION
## Summary
- allow pipeline steps to inject additional stages for dynamic branching
- add operations stage to run sympy helpers or agents one operation at a time
- test conditional operation execution and updated call sequencing

## Testing
- `pre-commit run --files twin_generator/pipeline.py tests/test_pipeline.py`
- `pytest tests/test_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899edfb9bf08330b034353bc78b1a8f