### PR TITLE
feat: add symbolic reasoning agents

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -39,6 +39,10 @@ def test_generate_twin_success(monkeypatch: pytest.MonkeyPatch) -> None:
             if isinstance(input, int):
                 return SimpleNamespace(final_output="extra_done")
             return SimpleNamespace(final_output='{"x": 1}')
+        if name == "SymbolicSolveAgent":
+            return SimpleNamespace(final_output="sym_solved")
+        if name == "SymbolicSimplifyAgent":
+            return SimpleNamespace(final_output="sym_simplified")
         if name == "StemChoiceAgent":
             return SimpleNamespace(final_output='{"twin_stem": "What is 1?", "choices": [1], "rationale": "r"}')
         if name == "FormatterAgent":
@@ -65,6 +69,9 @@ def test_generate_twin_success(monkeypatch: pytest.MonkeyPatch) -> None:
         "TemplateAgent",
         "QAAgent",
         "SampleAgent",
+        "QAAgent",
+        "SymbolicSolveAgent",
+        "SymbolicSimplifyAgent",
         "QAAgent",
         "QAAgent",
         "QAAgent",

--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -5,7 +5,8 @@ ParserAgent = Agent(
     name="ParserAgent",
     instructions=(
         "Take the source problem + solution and return JSON detailing variables, "
-        "relations, constraints, any visuals, and the answer format."
+        "relations, constraints, any visuals, and the answer format, ensuring coverage through "
+        "extremely advanced math operations."
     ),
     model="gpt-4o",
 )
@@ -14,7 +15,7 @@ ConceptAgent = Agent(
     name="ConceptAgent",
     instructions=(
         "From the parsed JSON, identify the key concept(s) and outline the canonical "
-        "solution path in ordered steps."
+        "solution path in ordered steps, ensuring coverage through extremely advanced math operations."
     ),
     model="gpt-4o",
 )
@@ -23,7 +24,7 @@ TemplateAgent = Agent(
     name="TemplateAgent",
     instructions=(
         "Replace literals with symbols; provide domains; include a `visual` field "
-        "→ {type: none|graph|table, data: {…}}."
+        "→ {type: none|graph|table, data: {…}}, ensuring coverage through extremely advanced math operations."
     ),
     model="gpt-4o",
 )
@@ -33,7 +34,7 @@ SampleAgent = Agent(
     instructions=(
         "Given a parameterized math problem template, generate a candidate "
         "parameter set and compute output. Return only the parameter mapping "
-        "as valid JSON without any prose."
+        "as valid JSON without any prose, ensuring coverage through extremely advanced math operations."
     ),
     model="gpt-4o",
 )
@@ -43,7 +44,7 @@ StemChoiceAgent = Agent(
     instructions=(
         "Using the *parameter template* and the sampled params, draft a **new SAT-style** equation problem "
         "that tests the same concept but with surface variation. Return only JSON with keys: "
-        "twin_stem, choices[], rationale."
+        "twin_stem, choices[], rationale, ensuring coverage through extremely advanced math operations."
     ),
     model="gpt-4o",
 )
@@ -52,7 +53,8 @@ FormatterAgent = Agent(
     name="FormatterAgent",
     instructions=(
         "Return minified JSON with fields: twin_stem, choices[], answer_index, "
-        "answer_value, rationale, graph_path?, table_html?. Validate internal consistency."
+        "answer_value, rationale, graph_path?, table_html?. Validate internal consistency while "
+        "ensuring coverage through extremely advanced math operations."
     ),
     model="gpt-4o",
 )
@@ -60,8 +62,26 @@ FormatterAgent = Agent(
 QAAgent = Agent(
     name="QAAgent",
     instructions=(
-        "Validate the previous step's output for correctness and internal consistency. "
-        "Return 'pass' if the output is sound, otherwise return a brief reason."
+        "Validate the previous step's output for correctness and internal consistency, ensuring coverage through "
+        "extremely advanced math operations. Return 'pass' if the output is sound, otherwise return a brief reason."
+    ),
+    model="gpt-4o",
+)
+
+SymbolicSolveAgent = Agent(
+    name="SymbolicSolveAgent",
+    instructions=(
+        "Handle heavy symbolic equation solving tasks with precision, ensuring coverage through "
+        "extremely advanced math operations."
+    ),
+    model="gpt-4o",
+)
+
+SymbolicSimplifyAgent = Agent(
+    name="SymbolicSimplifyAgent",
+    instructions=(
+        "Perform deep symbolic simplification and manipulation while ensuring coverage through "
+        "extremely advanced math operations."
     ),
     model="gpt-4o",
 )
@@ -74,5 +94,6 @@ __all__ = [
     "StemChoiceAgent",
     "FormatterAgent",
     "QAAgent",
+    "SymbolicSolveAgent",
+    "SymbolicSimplifyAgent",
 ]
-


### PR DESCRIPTION
## Summary
- expand agent instructions to cover extremely advanced math operations
- introduce SymbolicSolveAgent and SymbolicSimplifyAgent for heavy symbolic reasoning
- wire symbolic reasoning step into pipeline and update tests

## Testing
- `pre-commit run --files twin_generator/agents.py twin_generator/pipeline.py tests/test_pipeline.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f876ae408330aeb8296cf24f846b