### PR TITLE
Retry pipeline steps until QA passes

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -104,3 +104,36 @@ def test_generate_twin_agent_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
     assert "params" not in out
 
+
+def test_generate_twin_qa_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    call_counts: dict[str, int] = {}
+
+    def mock_run_sync(agent: Any, input: Any) -> SimpleNamespace:
+        name = agent.name
+        call_counts[name] = call_counts.get(name, 0) + 1
+        if name == "ParserAgent":
+            return SimpleNamespace(final_output="parsed")
+        if name == "ConceptAgent":
+            return SimpleNamespace(final_output="concept")
+        if name == "TemplateAgent":
+            return SimpleNamespace(final_output='{"visual": {"type": "none"}, "answer_expression": "0"}')
+        if name == "SampleAgent":
+            return SimpleNamespace(final_output='{}')
+        if name == "StemChoiceAgent":
+            return SimpleNamespace(final_output='{"twin_stem": "Q", "choices": [1], "rationale": "r"}')
+        if name == "FormatterAgent":
+            return SimpleNamespace(final_output='{"twin_stem": "Q", "choices": [1], "answer_index": 0, "answer_value": 1, "rationale": "r"}')
+        if name == "QAAgent":
+            # First QA check fails; subsequent ones pass
+            return SimpleNamespace(final_output="fail" if call_counts[name] == 1 else "pass")
+        raise AssertionError("unexpected agent")
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    out = pipeline.generate_twin("p", "s")
+    assert out.get("error") is None
+    # Parser step should have been retried due to QA failure
+    assert call_counts.get("ParserAgent") == 2
+    # QAAgent called once per step plus the extra retry (total 10)
+    assert call_counts.get("QAAgent") == 10
+

--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -43,10 +43,20 @@ class _Graph:
 
 
 class _Runner:
-    """Minimal re‑implementation of a sequential task executor with QA checks."""
+    """Minimal re‑implementation of a sequential task executor with QA checks.
+
+    The runner executes each pipeline step sequentially and performs a QA check
+    after every step.  If the QA step fails the corresponding pipeline step is
+    retried until QA passes.  Optionally a maximum number of QA retries can be
+    supplied to prevent infinite loops.
+    """
 
     def __init__(
-        self, graph: _Graph, *, verbose: bool = False, qa_max_retries: int = 2
+        self,
+        graph: _Graph,
+        *,
+        verbose: bool = False,
+        qa_max_retries: int | None = None,
     ) -> None:
         self.graph = graph
         self.verbose = verbose
@@ -63,7 +73,7 @@ class _Runner:
             while True:
                 before = dict(data)
                 if self.verbose:
-                    print(f"[twin-generator] {name}…")
+                    print(f"[twin-generator] {name} attempt {attempts + 1}")
                 data = step(data)
                 if "error" in data:
                     break
@@ -75,12 +85,19 @@ class _Runner:
                 except Exception as exc:  # pragma: no cover - defensive
                     data["error"] = f"QAAgent failed: {exc}"
                     break
+                if self.verbose:
+                    print(
+                        f"[twin-generator] {name} QA round {attempts + 1}: {qa_out}"
+                    )
                 if qa_out == "pass":
                     if next_steps:
                         steps[idx + 1 : idx + 1] = next_steps
                     break
                 attempts += 1
-                if attempts > self.qa_max_retries:
+                if (
+                    self.qa_max_retries is not None
+                    and attempts >= self.qa_max_retries
+                ):
                     data["error"] = f"QA failed for {name}: {qa_out}"
                     break
                 data = before


### PR DESCRIPTION
## Summary
- retry each pipeline step until QA passes, with per-step and QA-round logging
- add regression test covering QA retry behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f8c9a8f08330a96a34e882947931