### PR TITLE
Break long test string to satisfy flake8

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -129,7 +129,12 @@ def test_generate_twin_qa_retry(monkeypatch: pytest.MonkeyPatch) -> None:
         if name == "StemChoiceAgent":
             return SimpleNamespace(final_output='{"twin_stem": "Q", "choices": [1], "rationale": "r"}')
         if name == "FormatterAgent":
-            return SimpleNamespace(final_output='{"twin_stem": "Q", "choices": [1], "answer_index": 0, "answer_value": 1, "rationale": "r"}')
+            return SimpleNamespace(
+                final_output=(
+                    '{"twin_stem": "Q", "choices": [1], '
+                    '"answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                )
+            )
         if name == "QAAgent":
             # First QA check fails; subsequent ones pass
             return SimpleNamespace(final_output="fail" if call_counts[name] == 1 else "pass")


### PR DESCRIPTION
## Summary
- fix flake8 E501 by wrapping long JSON string in tests

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa6ae3e308330b7f9b72e320960ce