### PR TITLE
Refactor operations to use tool-enabled agents

### DIFF
--- a/agents/tool.py
+++ b/agents/tool.py
@@ -1,11 +1,53 @@
 """Utilities for defining simple function-based tools."""
 
-from typing import Any, Callable, TypeVar
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, TypeVar, get_type_hints
 
 
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def function_tool(func: F) -> F:
-    """Return the provided function as a tool with preserved type."""
-    return func
+def _annotation_to_type(ann: Any) -> str:
+    """Map a Python type annotation to a JSON schema primitive."""
+    if ann in (int, float):
+        return "number"
+    if ann is bool:
+        return "boolean"
+    if ann in (dict, list):
+        return "object"
+    return "string"
+
+
+def function_tool(func: F) -> dict[str, Any]:
+    """Return an OpenAI tool definition for ``func``.
+
+    The returned dictionary follows the "tool" schema understood by the
+    OpenAI APIs and can be supplied directly when invoking a model so it may
+    call the wrapped function via tool-calling.
+    """
+
+    sig = inspect.signature(func)
+    hints = get_type_hints(func)
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for name, param in sig.parameters.items():
+        ann = hints.get(name, str)
+        properties[name] = {"type": _annotation_to_type(ann)}
+        if param.default is inspect._empty:
+            required.append(name)
+
+    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+
+    return {
+        "type": "function",
+        "function": {
+            "name": func.__name__,
+            "description": func.__doc__ or "",
+            "parameters": schema,
+        },
+    }

--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -86,6 +86,15 @@ SymbolicSimplifyAgent = Agent(
     model="gpt-5-mini",
 )
 
+OperationsAgent = Agent(
+    name="OperationsAgent",
+    instructions=(
+        "Given the current pipeline data and a list of operations, invoke any provided tools "
+        "to compute intermediate results. Return only JSON with any newly derived fields."
+    ),
+    model="gpt-5-mini",
+)
+
 __all__ = [
     "ParserAgent",
     "ConceptAgent",
@@ -96,4 +105,5 @@ __all__ = [
     "QAAgent",
     "SymbolicSolveAgent",
     "SymbolicSimplifyAgent",
+    "OperationsAgent",
 ]


### PR DESCRIPTION
## Summary
- expose helper functions as JSON-schema tools via `function_tool`
- let `Runner.run_sync` accept tool definitions and propagate them to OpenAI calls
- delegate operation execution to a new `OperationsAgent` with QA validation

## Testing
- `pre-commit run --files agents/tool.py agents/run.py twin_generator/agents.py twin_generator/pipeline.py tests/test_pipeline.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ab75a02d48330acb84ade9aebea64