### PR TITLE
Handle non-dict visual specs in pipeline visual step

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -142,3 +142,9 @@ def test_generate_twin_qa_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     # QAAgent called once per step plus the extra retry (total 10)
     assert call_counts.get("QAAgent") == 10
 
+
+def test_step_visual_handles_non_dict() -> None:
+    data = {"template": {"visual": "not-a-dict"}}
+    out = pipeline._step_visual(dict(data))
+    assert out == data
+

--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -224,11 +224,14 @@ def _step_operations(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def _step_visual(data: dict[str, Any]) -> dict[str, Any]:
-    visual = data.get("template", {}).get("visual") or {"type": "none"}
+    visual = data.get("template", {}).get("visual")
+    if not isinstance(visual, dict):
+        visual = {"type": "none"}
     force = bool(data.get("force_graph"))
     user_spec = data.get("graph_spec")
 
-    if visual.get("type") == "graph":
+    vtype = visual.get("type")
+    if vtype == "graph":
         spec = visual.get("data", {}) or C.DEFAULT_GRAPH_SPEC
         data["graph_path"] = _render_graph(json.dumps(spec))
         return data
@@ -238,7 +241,7 @@ def _step_visual(data: dict[str, Any]) -> dict[str, Any]:
         data["graph_path"] = _render_graph(json.dumps(gspec))
         return data
 
-    if visual.get("type") == "table":
+    if vtype == "table":
         data["table_html"] = _make_html_table(json.dumps(visual.get("data", {})))
     return data
 


### PR DESCRIPTION
## Summary
- Guard `_step_visual` against non-dictionary `visual` specs and refactor type handling
- Add regression test ensuring visual step gracefully ignores invalid visual specs

## Testing
- `pytest -q`
- `pre-commit run --files twin_generator/pipeline.py tests/test_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_689ac6709fbc83308f7da411fcca712e