### PR TITLE
Add tool-calling support to runner

### DIFF
--- a/agents/tool.py
+++ b/agents/tool.py
@@ -52,4 +52,5 @@ def function_tool(func: F) -> dict[str, Any]:
         "name": name,
         "description": description,
         "parameters": schema,
+        "_func": func,
     }


### PR DESCRIPTION
## Summary
- extend function_tool to retain original callable for local execution
- enhance Runner.run_sync to execute and submit tool call outputs until completion
- ensure runner casts tool names to strings for type safety

## Testing
- `pre-commit run --files agents/run.py agents/tool.py`
- `mypy twin_generator`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf38276148330b972afc4e63ce14b