### PR TITLE
Handle empty agent output and add sympy dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8
 mypy
 pre-commit
+sympy

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -105,6 +105,22 @@ def test_generate_twin_agent_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "params" not in out
 
 
+def test_generate_twin_template_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TemplateAgent returning empty output should surface a clear error."""
+
+    def mock_run_sync(agent: Any, input: Any, tools: Any | None = None) -> SimpleNamespace:
+        if agent.name == "QAAgent":
+            return SimpleNamespace(final_output="pass")
+        if agent.name == "TemplateAgent":
+            return SimpleNamespace(final_output="")
+        return SimpleNamespace(final_output="ok")
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    out = pipeline.generate_twin("p", "s")
+    assert out.get("error") == "TemplateAgent failed: Agent output was empty"
+
+
 def test_generate_twin_qa_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     call_counts: dict[str, int] = {}
 

--- a/twin_generator/utils.py
+++ b/twin_generator/utils.py
@@ -13,8 +13,12 @@ from typing import Any, cast
 
 def get_final_output(res: Any) -> str:  # noqa: ANN401 – generic return
     """Extract the best‑guess textual payload from an Agents SDK response."""
-    out = getattr(res, "final_output", None) or getattr(res, "output", None) or getattr(res, "content", None) or res
-    return str(out)
+    for attr in ("final_output", "output", "content"):
+        if hasattr(res, attr):
+            val = getattr(res, attr)
+            if val is not None:
+                return str(val)
+    return str(res)
 
 
 # ---------------------------------------------------------------------------
@@ -23,6 +27,10 @@ def get_final_output(res: Any) -> str:  # noqa: ANN401 – generic return
 
 def safe_json(text: str) -> dict[str, Any]:
     """Best‑effort JSON repair loader with fenced‑code and bracket fallbacks."""
+    text = text.strip()
+    if not text:
+        raise ValueError("Agent output was empty")
+
     fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
     if fenced:
         text = fenced.group(1)


### PR DESCRIPTION
## Summary
- Improve agent response handling to avoid treating empty `final_output` as missing
- Report empty agent responses explicitly during JSON parsing
- Add regression test for TemplateAgent returning no data
- Include `sympy` in development requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c375672ac8330a66b5910757e84b0