### PR TITLE
Restrict TemplateAgent tool access

### DIFF
--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -39,7 +39,10 @@ from .utils import (
 __all__ = ["generate_twin"]
 
 
+# Default tools available to most agents.  TemplateAgent is intentionally given
+# a more restrictive list that excludes ``render_graph_tool``.
 _TOOLS = [calc_answer_tool, render_graph_tool, make_html_table_tool]
+_TEMPLATE_TOOLS = [calc_answer_tool, make_html_table_tool]
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +164,7 @@ def _step_template(data: dict[str, Any]) -> dict[str, Any]:
         res = AgentsRunner.run_sync(
             TemplateAgent,
             input=json.dumps({"parsed": data["parsed"], "concept": data["concept"]}),
-            tools=_TOOLS,
+            tools=_TEMPLATE_TOOLS,
         )
         data["template"] = safe_json(get_final_output(res))
     except Exception as exc:  # pragma: no cover - defensive

--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -40,9 +40,9 @@ __all__ = ["generate_twin"]
 
 
 # Default tools available to most agents.  TemplateAgent is intentionally given
-# a more restrictive list that excludes ``render_graph_tool``.
+# a more restrictive list that excludes ``render_graph_tool`` and ``make_html_table_tool``.
 _TOOLS = [calc_answer_tool, render_graph_tool, make_html_table_tool]
-_TEMPLATE_TOOLS = [calc_answer_tool, make_html_table_tool]
+_TEMPLATE_TOOLS = [calc_answer_tool]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- prevent TemplateAgent from using `render_graph_tool`
- keep visual step rendering with internal `_render_graph`

## Testing
- `pre-commit run --files twin_generator/pipeline.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d374d76a0833098eb216531dcded1