### PR TITLE
Validate numeric params in pipeline

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -164,3 +164,26 @@ def test_step_visual_handles_non_dict() -> None:
     out = pipeline._step_visual(dict(data))
     assert out == data
 
+
+def test_step_sample_rejects_invalid_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_run_sync(agent: Any, input: Any, tools: Any | None = None) -> SimpleNamespace:
+        assert agent.name == "SampleAgent"
+        return SimpleNamespace(final_output='{"x": "oops"}')
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    out = pipeline._step_sample({"template": {}})
+    assert out.get("error") == "SampleAgent produced non-numeric params: x='oops'"
+
+
+def test_step_operations_rejects_invalid_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_run_sync(agent: Any, input: Any, tools: Any | None = None) -> SimpleNamespace:
+        assert agent.name == "OperationsAgent"
+        return SimpleNamespace(final_output='{"params": {"x": "oops"}}')
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    data = {"template": {"operations": [1]}, "params": {}}
+    out = pipeline._step_operations(data)
+    assert out.get("error") == "OperationsAgent produced non-numeric params: x='oops'"
+

--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -25,6 +25,7 @@ from .tools import (
     _calc_answer,      # internal helper functions (NOT the FunctionTool wrappers!)
     _make_html_table,
     _render_graph,
+    _sanitize_params,
     calc_answer_tool,
     make_html_table_tool,
     render_graph_tool,
@@ -179,7 +180,16 @@ def _step_sample(data: dict[str, Any]) -> dict[str, Any]:
             input=json.dumps({"template": data["template"]}),
             tools=_TOOLS,
         )
-        data["params"] = safe_json(get_final_output(res))
+        params = safe_json(get_final_output(res))
+        if not isinstance(params, dict):
+            data["error"] = "SampleAgent produced non-dict params"
+            return data
+        _, skipped = _sanitize_params(params)
+        if skipped:
+            bad = ", ".join(f"{k}={params[k]!r}" for k in skipped)
+            data["error"] = f"SampleAgent produced non-numeric params: {bad}"
+            return data
+        data["params"] = params
     except Exception as exc:  # pragma: no cover - defensive
         data["error"] = f"SampleAgent failed: {exc}"
     return data
@@ -220,6 +230,15 @@ def _step_operations(data: dict[str, Any]) -> dict[str, Any]:
         )
         out = safe_json(get_final_output(res))
         if isinstance(out, dict):
+            params_out = out.get("params")
+            if isinstance(params_out, dict):
+                _, skipped = _sanitize_params(params_out)
+                if skipped:
+                    bad = ", ".join(f"{k}={params_out[k]!r}" for k in skipped)
+                    data["error"] = (
+                        f"OperationsAgent produced non-numeric params: {bad}"
+                    )
+                    return data
             data.update(out)
     except Exception as exc:  # pragma: no cover - defensive
         data["error"] = f"OperationsAgent failed: {exc}"


### PR DESCRIPTION
## Summary
- factor out `_sanitize_params` helper and reuse in `_calc_answer`
- ensure `_step_sample` and `_step_operations` reject non-numeric parameters with explicit errors
- add tests covering invalid parameter handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2a2686a048330a234cf2099ae2d29