### PR TITLE
Clarify TemplateAgent output schema

### DIFF
--- a/docs/template_agent.md
+++ b/docs/template_agent.md
@@ -1,0 +1,29 @@
+# TemplateAgent Schema
+
+The `TemplateAgent` produces a JSON object describing a parameterized math problem.
+All keys and string values must be double-quoted, and the agent should return **only**
+this JSON object with no trailing explanation.
+
+## Expected Fields
+
+```json
+{
+  "template": "problem statement with symbolic parameters",
+  "domains": {"symbol": "domain description"},
+  "answer_expression": "expression using the symbols",
+  "operations": [{"expr": "...", "output": "..."}],
+  "visual": {"type": "none|graph|table", "data": {}}
+}
+```
+
+## Example
+
+```json
+{
+  "template": "Solve for x: a*x + b = c",
+  "domains": {"a": "nonzero real", "b": "real", "c": "real"},
+  "answer_expression": "(c - b) / a",
+  "operations": [{"expr": "a*x + b", "output": "lhs"}],
+  "visual": {"type": "none", "data": {}}
+}
+```

--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -20,11 +20,29 @@ ConceptAgent = Agent(
     model="gpt-5-mini",
 )
 
+# TemplateAgent expected schema:
+# {
+#   "template": "problem statement with symbolic parameters",
+#   "domains": {"symbol": "domain description", ...},
+#   "answer_expression": "expression using the symbols",
+#   "operations": [{"expr": "...", "output": "..."}],
+#   "visual": {"type": "none|graph|table", "data": {...}}
+# }
+# Example:
+# {
+#   "template": "Solve for x: a*x + b = c",
+#   "domains": {"a": "nonzero real", "b": "real", "c": "real"},
+#   "answer_expression": "(c - b) / a",
+#   "operations": [{"expr": "a*x + b", "output": "lhs"}],
+#   "visual": {"type": "none", "data": {}}
+# }
 TemplateAgent = Agent(
     name="TemplateAgent",
     instructions=(
         "Replace literals with symbols; provide domains; include a `visual` field "
-        "→ {type: none|graph|table, data: {…}}, ensuring coverage through extremely advanced math operations."
+        "→ {type: none|graph|table, data: {…}}. Return only a single JSON object with "
+        "double-quoted keys/values and no trailing text, ensuring coverage through "
+        "extremely advanced math operations."
     ),
     model="gpt-5-mini",
 )


### PR DESCRIPTION
## Summary
- Specify that TemplateAgent must return a single JSON object with double-quoted keys/values and no trailing text
- Document TemplateAgent's expected JSON schema and provide an illustrative example

## Testing
- `pytest`
- `mypy --config-file=mypy.ini twin_generator`


------
https://chatgpt.com/codex/tasks/task_e_68a2b52869b0833081b1804ee72640c4