### PR TITLE
Handle malformed JSON in safe_json

### DIFF
--- a/tests/test_safe_json.py
+++ b/tests/test_safe_json.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from twin_generator.utils import safe_json
+
+
+def test_safe_json_single_quotes() -> None:
+    out = safe_json("{'a': 1}")
+    assert out == {"a": 1}
+
+
+def test_safe_json_trailing_comma() -> None:
+    out = safe_json('{"a": 1,}')
+    assert out == {"a": 1}
+
+
+def test_safe_json_unbalanced_braces() -> None:
+    out = safe_json('{"a": 1')
+    assert out == {"a": 1}
+
+
+def test_safe_json_combined_issues() -> None:
+    out = safe_json("{'a': 1,")
+    assert out == {"a": 1}
+


### PR DESCRIPTION
## Summary
- Improve `safe_json` to repair single quotes, trailing commas, and unbalanced braces
- Add tests covering malformed JSON cases for `safe_json`

## Testing
- `pre-commit run --files twin_generator/utils.py tests/test_safe_json.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2b5358d9c8330b1259291f6e98139