### PR TITLE
Enforce strict JSON output and add QA tests

### DIFF
--- a/tests/test_json_enforcement.py
+++ b/tests/test_json_enforcement.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import twin_generator.pipeline as pipeline  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "bad_agent",
+    ["SampleAgent", "OperationsAgent", "StemChoiceAgent", "FormatterAgent"],
+)
+def test_generate_twin_invalid_json(monkeypatch: pytest.MonkeyPatch, bad_agent: str) -> None:
+    """Pipeline should surface clear errors when downstream agents return invalid JSON."""
+
+    def mock_run_sync(agent: Any, input: Any, tools: Any | None = None) -> SimpleNamespace:
+        name = agent.name
+        if name == "QAAgent":
+            return SimpleNamespace(final_output="pass")
+        if name == "ParserAgent":
+            return SimpleNamespace(final_output="parsed")
+        if name == "ConceptAgent":
+            return SimpleNamespace(final_output="concept")
+        if name == "TemplateAgent":
+            return SimpleNamespace(
+                final_output=(
+                    '{"visual": {"type": "none"}, "answer_expression": "x", '
+                    '"operations": [{"expr": "1", "output": "run_agent"}]}'
+                )
+            )
+        if name == "SampleAgent":
+            if bad_agent == "SampleAgent":
+                return SimpleNamespace(final_output="not json")
+            return SimpleNamespace(final_output='{"x": 1}')
+        if name == "SymbolicSolveAgent":
+            return SimpleNamespace(final_output="sym_solved")
+        if name == "SymbolicSimplifyAgent":
+            return SimpleNamespace(final_output="sym_simplified")
+        if name == "OperationsAgent":
+            if bad_agent == "OperationsAgent":
+                return SimpleNamespace(final_output="not json")
+            return SimpleNamespace(final_output='{"run_agent": 1}')
+        if name == "StemChoiceAgent":
+            if bad_agent == "StemChoiceAgent":
+                return SimpleNamespace(final_output="not json")
+            return SimpleNamespace(
+                final_output='{"twin_stem": "Q", "choices": [1], "rationale": "r"}'
+            )
+        if name == "FormatterAgent":
+            if bad_agent == "FormatterAgent":
+                return SimpleNamespace(final_output="not json")
+            return SimpleNamespace(
+                final_output=(
+                    '{"twin_stem": "Q", "choices": [1], '
+                    '"answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                )
+            )
+        raise AssertionError(f"unexpected agent {name}")
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    out = pipeline.generate_twin("p", "s")
+    assert out.get("error", "").startswith(f"{bad_agent} failed:")

--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -4,7 +4,8 @@ from agents import Agent  # type: ignore
 ParserAgent = Agent(
     name="ParserAgent",
     instructions=(
-        "Take the source problem + solution and return JSON detailing variables, "
+        "Take the source problem + solution and return only a single JSON object "
+        "with double-quoted keys/values and no trailing text detailing variables, "
         "relations, constraints, any visuals, and the answer format, ensuring coverage through "
         "extremely advanced math operations."
     ),
@@ -51,8 +52,9 @@ SampleAgent = Agent(
     name="SampleAgent",
     instructions=(
         "Given a parameterized math problem template, generate a candidate "
-        "parameter set and compute output. Return only the parameter mapping "
-        "as valid JSON without any prose, ensuring coverage through extremely advanced math operations."
+        "parameter set and compute output. Return only a single JSON object "
+        "with double-quoted keys/values and no trailing text representing the "
+        "parameter mapping, ensuring coverage through extremely advanced math operations."
     ),
     model="gpt-5-mini",
 )
@@ -61,7 +63,8 @@ StemChoiceAgent = Agent(
     name="StemChoiceAgent",
     instructions=(
         "Using the *parameter template* and the sampled params, draft a **new SAT-style** equation problem "
-        "that tests the same concept but with surface variation. Return only JSON with keys: "
+        "that tests the same concept but with surface variation. Return only a single JSON object "
+        "with double-quoted keys/values and no trailing text containing keys: "
         "twin_stem, choices[], rationale, ensuring coverage through extremely advanced math operations."
     ),
     model="gpt-5-mini",
@@ -70,7 +73,8 @@ StemChoiceAgent = Agent(
 FormatterAgent = Agent(
     name="FormatterAgent",
     instructions=(
-        "Return minified JSON with fields: twin_stem, choices[], answer_index, "
+        "Return only a single minified JSON object with double-quoted keys/values "
+        "and no trailing text containing fields: twin_stem, choices[], answer_index, "
         "answer_value, rationale, graph_path?, table_html?. Validate internal consistency while "
         "ensuring coverage through extremely advanced math operations."
     ),
@@ -80,7 +84,8 @@ FormatterAgent = Agent(
 QAAgent = Agent(
     name="QAAgent",
     instructions=(
-        "Validate the previous step's output for correctness and internal consistency, ensuring coverage through "
+        "Validate the previous step's output for correctness, strict JSON formatting "
+        "(double-quoted keys/values with no trailing text), and internal consistency, ensuring coverage through "
         "extremely advanced math operations. Return 'pass' if the output is sound, otherwise return a brief reason."
     ),
     model="gpt-5-mini",
@@ -108,7 +113,8 @@ OperationsAgent = Agent(
     name="OperationsAgent",
     instructions=(
         "Given the current pipeline data and a list of operations, invoke any provided tools "
-        "to compute intermediate results. Return only JSON with any newly derived fields."
+        "to compute intermediate results. Return only a single JSON object with double-quoted "
+        "keys/values and no trailing text containing any newly derived fields."
     ),
     model="gpt-5-mini",
 )


### PR DESCRIPTION
## Summary
- Require all JSON-producing agents to return a single, strictly formatted JSON object
- Make QAAgent responsible for verifying strict JSON formatting
- Add pipeline tests covering invalid JSON from downstream agents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2ca60b7c08330953af8706e04f1d8