### PR TITLE
Handle invalid JSON from ParserAgent

### DIFF
--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -142,8 +142,13 @@ def _step_parse(data: dict[str, Any]) -> dict[str, Any]:
             input=data["problem_text"] + "\n" + data["solution"],
             tools=_TOOLS,
         )
-        data["parsed"] = get_final_output(res)
     except Exception as exc:  # pragma: no cover - defensive
+        data["error"] = f"ParserAgent failed: {exc}"
+        return data
+
+    try:
+        data["parsed"] = safe_json(get_final_output(res))
+    except ValueError as exc:
         data["error"] = f"ParserAgent failed: {exc}"
     return data
 


### PR DESCRIPTION
## Summary
- parse ParserAgent output with safe_json in _step_parse
- add regression test for invalid ParserAgent JSON

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2cbae7f9083308a844bf77f51c5d7