### PR TITLE
Retry steps on JSON serialization failures

### DIFF
--- a/tests/test_json_enforcement.py
+++ b/tests/test_json_enforcement.py
@@ -25,7 +25,7 @@ def test_generate_twin_invalid_json(monkeypatch: pytest.MonkeyPatch, bad_agent: 
         if name == "QAAgent":
             return SimpleNamespace(final_output="pass")
         if name == "ParserAgent":
-            return SimpleNamespace(final_output="parsed")
+            return SimpleNamespace(final_output="{}")
         if name == "ConceptAgent":
             return SimpleNamespace(final_output="concept")
         if name == "TemplateAgent":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -263,7 +263,7 @@ def test_sample_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fail: b
         name = agent.name
         call_counts[name] = call_counts.get(name, 0) + 1
         if name == "ParserAgent":
-            return SimpleNamespace(final_output="parsed")
+            return SimpleNamespace(final_output="{}")
         if name == "ConceptAgent":
             return SimpleNamespace(final_output="concept")
         if name == "TemplateAgent":
@@ -305,7 +305,7 @@ def test_operations_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fai
         name = agent.name
         call_counts[name] = call_counts.get(name, 0) + 1
         if name == "ParserAgent":
-            return SimpleNamespace(final_output="parsed")
+            return SimpleNamespace(final_output="{}")
         if name == "ConceptAgent":
             return SimpleNamespace(final_output="concept")
         if name == "TemplateAgent":
@@ -351,7 +351,7 @@ def test_stem_choice_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fa
         name = agent.name
         call_counts[name] = call_counts.get(name, 0) + 1
         if name == "ParserAgent":
-            return SimpleNamespace(final_output="parsed")
+            return SimpleNamespace(final_output="{}")
         if name == "ConceptAgent":
             return SimpleNamespace(final_output="concept")
         if name == "TemplateAgent":
@@ -393,7 +393,7 @@ def test_formatter_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fail
         name = agent.name
         call_counts[name] = call_counts.get(name, 0) + 1
         if name == "ParserAgent":
-            return SimpleNamespace(final_output="parsed")
+            return SimpleNamespace(final_output="{}")
         if name == "ConceptAgent":
             return SimpleNamespace(final_output="concept")
         if name == "TemplateAgent":

--- a/tests/test_runner_serialization.py
+++ b/tests/test_runner_serialization.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import twin_generator.pipeline as pipeline  # noqa: E402
+
+
+@pytest.mark.parametrize("always_fail", [False, True])
+def test_runner_handles_non_serializable(monkeypatch: pytest.MonkeyPatch, always_fail: bool) -> None:
+    """_Runner should retry steps producing non-serializable data and surface errors."""
+
+    call_counts: dict[str, int] = {}
+
+    def mock_run_sync(agent: Any, input: Any, tools: Any | None = None) -> SimpleNamespace:
+        name = agent.name
+        call_counts[name] = call_counts.get(name, 0) + 1
+        if name == "ParserAgent":
+            if always_fail or call_counts[name] == 1:
+                return SimpleNamespace(final_output={1})  # not JSON serializable
+            return SimpleNamespace(final_output={"ok": 1})
+        if name == "QAAgent":
+            return SimpleNamespace(final_output="pass")
+        raise AssertionError(f"unexpected agent {name}")
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    def _step_bad(data: dict[str, Any]) -> dict[str, Any]:
+        res = pipeline.AgentsRunner.run_sync(pipeline.ParserAgent, input="x")
+        data["bad"] = res.final_output
+        return data
+
+    monkeypatch.setattr(pipeline, "_JSON_STEPS", set(pipeline._JSON_STEPS | {"bad"}))
+
+    runner = pipeline._Runner(pipeline._Graph([_step_bad]), qa_max_retries=2)
+    out = runner.run({})["output"]
+    if always_fail:
+        assert out["error"].startswith("QA failed for bad: non-serializable")
+        assert call_counts.get("ParserAgent") == 2
+        assert call_counts.get("QAAgent") is None
+    else:
+        assert out.get("error") is None
+        assert out["bad"] == {"ok": 1}
+        assert call_counts.get("ParserAgent") == 2
+        assert call_counts.get("QAAgent") == 1


### PR DESCRIPTION
## Summary
- register pipeline steps that must produce JSON
- retry QA when step output can't be serialized and report error after max retries
- test `_Runner` behavior on non-serializable agent responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2cfe7e4a88330930b502fbb049b19