### PR TITLE
Enhance tool annotation handling and cache introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ python -m twin_generator.cli --demo
 
 Passing `--graph-demo` runs a demo that produces a graph visual. Append `--preview` to automatically preview the generated graph if any. Use `--verbose` to see each pipeline step.
 
+## Tool annotation support
+
+The `agents.tool.function_tool` helper derives a JSON schema for the parameters of a wrapped function using its type hints. Supported annotation patterns include:
+
+- `int` and `float` → `"number"`
+- `bool` → `"boolean"`
+- `str` → `"string"`
+- container types such as `list[T]`, `tuple[T, ...]`, and `set[T]` → `"array"`
+- mappings like `dict[K, V]` → `"object"`
+- `Optional[T]` is treated the same as `T`
+- `Union` is supported when all members resolve to the same JSON schema type; heterogeneous unions fall back to `"string"`
+
 ## Development
 
 Run tests with `pytest` and type checking with `mypy`:

--- a/tests/test_function_tool.py
+++ b/tests/test_function_tool.py
@@ -1,0 +1,37 @@
+import inspect
+import typing
+from pathlib import Path
+from typing import Optional, Union
+from unittest.mock import patch
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from agents.tool import _INTROSPECTION_CACHE, function_tool
+
+
+def test_annotation_to_type_handles_complex_signatures():
+    def f(a: int, b: Optional[float], c: list[str], d: Union[int, float], e: Union[int, str]):
+        pass
+
+    tool = function_tool(f)
+    props = tool["parameters"]["properties"]
+    assert props["a"]["type"] == "number"
+    assert props["b"]["type"] == "number"
+    assert props["c"]["type"] == "array"
+    assert props["d"]["type"] == "number"
+    assert props["e"]["type"] == "string"
+
+
+def test_function_tool_caches_introspection():
+    def g(x: int) -> int:
+        return x
+
+    _INTROSPECTION_CACHE.clear()
+    with patch("agents.tool.inspect.signature", wraps=inspect.signature) as sig, \
+         patch("agents.tool.get_type_hints", wraps=typing.get_type_hints) as hints:
+        function_tool(g)
+        function_tool(g)
+        assert sig.call_count == 1
+        assert hints.call_count == 1


### PR DESCRIPTION
## Summary
- Support Optional, Union, and container type hints when mapping annotations to JSON schema primitives
- Cache function signature and type hints to avoid repeated introspection
- Document supported annotation patterns for tools
- Add tests for complex signatures and introspection caching

## Testing
- `pip install sympy -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2d63eb71083308b2ff0c08ebe8003