### PR TITLE
feat: improve tolerant JSON parsing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ flake8
 mypy
 pre-commit
 sympy
+json5

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -125,7 +125,10 @@ def test_generate_twin_parser_invalid_json(
     out = pipeline.generate_twin("p", "s")
     assert (
         out.get("error")
-        == "ParserAgent failed: Agent output was not valid JSON: not json..."
+        == (
+            "ParserAgent failed: Agent output was not valid JSON even after repair. "
+            "Original snippet: not json... Repaired snippet: not json..."
+        )
     )
     assert call_order == ["ParserAgent"]
 
@@ -280,7 +283,10 @@ def test_sample_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fail: b
             return SimpleNamespace(final_output='{"twin_stem": "Q", "choices": [1], "rationale": "r"}')
         if name == "FormatterAgent":
             return SimpleNamespace(
-                final_output='{"twin_stem": "Q", "choices": [1], "answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                final_output=(
+                    '{"twin_stem": "Q", "choices": [1], '
+                    '"answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                )
             )
         if name == "QAAgent":
             return SimpleNamespace(final_output="pass")
@@ -310,7 +316,10 @@ def test_operations_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fai
             return SimpleNamespace(final_output="concept")
         if name == "TemplateAgent":
             return SimpleNamespace(
-                final_output='{"visual": {"type": "none"}, "answer_expression": "x", "operations": [{"expr": "1", "output": "run_agent"}]}'
+                final_output=(
+                    '{"visual": {"type": "none"}, "answer_expression": "x", '
+                    '"operations": [{"expr": "1", "output": "run_agent"}]}'
+                )
             )
         if name == "SampleAgent":
             return SimpleNamespace(final_output='{"x": 1}')
@@ -326,7 +335,10 @@ def test_operations_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fai
             return SimpleNamespace(final_output='{"twin_stem": "Q", "choices": [1], "rationale": "r"}')
         if name == "FormatterAgent":
             return SimpleNamespace(
-                final_output='{"twin_stem": "Q", "choices": [1], "answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                final_output=(
+                    '{"twin_stem": "Q", "choices": [1], '
+                    '"answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                )
             )
         if name == "QAAgent":
             return SimpleNamespace(final_output="pass")
@@ -368,7 +380,10 @@ def test_stem_choice_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fa
             return SimpleNamespace(final_output='{"twin_stem": "Q", "choices": [1], "rationale": "r"}')
         if name == "FormatterAgent":
             return SimpleNamespace(
-                final_output='{"twin_stem": "Q", "choices": [1], "answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                final_output=(
+                    '{"twin_stem": "Q", "choices": [1], '
+                    '"answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                )
             )
         if name == "QAAgent":
             return SimpleNamespace(final_output="pass")
@@ -410,7 +425,10 @@ def test_formatter_agent_json_retry(monkeypatch: pytest.MonkeyPatch, always_fail
             if always_fail or call_counts[name] == 1:
                 return SimpleNamespace(final_output="not json")
             return SimpleNamespace(
-                final_output='{"twin_stem": "Q", "choices": [1], "answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                final_output=(
+                    '{"twin_stem": "Q", "choices": [1], '
+                    '"answer_index": 0, "answer_value": 1, "rationale": "r"}'
+                )
             )
         if name == "QAAgent":
             return SimpleNamespace(final_output="pass")

--- a/tests/test_safe_json.py
+++ b/tests/test_safe_json.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from twin_generator.utils import safe_json
 
 
@@ -21,4 +23,16 @@ def test_safe_json_unbalanced_braces() -> None:
 def test_safe_json_combined_issues() -> None:
     out = safe_json("{'a': 1,")
     assert out == {"a": 1}
+
+
+def test_safe_json_with_comments() -> None:
+    out = safe_json('{"a":1,// c\n"b":2}')
+    assert out == {"a": 1, "b": 2}
+
+
+def test_safe_json_error_message() -> None:
+    with pytest.raises(ValueError) as exc:
+        safe_json("not json")
+    msg = str(exc.value)
+    assert "Original snippet: not json" in msg
 


### PR DESCRIPTION
## Summary
- parse agent output with optional `json5` and helper repair functions
- surface original and repaired snippets when JSON parsing fails
- add tests for comment handling and error messaging

## Testing
- `pre-commit run --files twin_generator/utils.py requirements-dev.txt tests/test_safe_json.py tests/test_pipeline.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2d655aeb8833095f27320f3177bb8