### PR TITLE
Fix mypy issues and improve JSON comment handling

### DIFF
--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -429,6 +429,8 @@ def _step_format(data: dict[str, Any]) -> dict[str, Any]:
         data["error"] = err
         return data
 
+    out = cast(dict[str, Any], out)
+
     # Pass‑through assets in case the formatter dropped them
     if "graph_path" in data:
         out["graph_path"] = data["graph_path"]

--- a/twin_generator/utils.py
+++ b/twin_generator/utils.py
@@ -45,6 +45,9 @@ def _repair_json(text: str) -> str:
     """Attempt light‑weight JSON repairs and return the adjusted string."""
     repaired = text
     repaired = re.sub(r"(?<!\\)'", '"', repaired)
+    # Strip both line (`//`) and block (`/* */`) comments
+    repaired = re.sub(r"//.*?(?=\n|$)", "", repaired)
+    repaired = re.sub(r"/\*.*?\*/", "", repaired, flags=re.DOTALL)
     open_braces = repaired.count("{")
     close_braces = repaired.count("}")
     if open_braces > close_braces:


### PR DESCRIPTION
## Summary
- Cast FormatterAgent output to dictionary to satisfy mypy and allow safe indexing
- Strip line and block comments when repairing JSON in `safe_json`

## Testing
- `python -m mypy twin_generator`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2d9a03e748330b3bfc2676bda107f