### PR TITLE
Configure logging in CLI for verbose output

### DIFF
--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,0 +1,24 @@
+import logging
+from twin_generator import cli
+
+def test_verbose_emits_logs(monkeypatch, capsys):
+    root = logging.getLogger()
+    old_handlers = root.handlers[:]
+    old_level = root.level
+    for h in old_handlers:
+        root.removeHandler(h)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    def fake_generate_twin(*args, **kwargs):
+        logging.getLogger().debug("debug message")
+        return {}
+
+    monkeypatch.setattr(cli, "generate_twin", fake_generate_twin)
+    try:
+        cli.main(["--demo", "--verbose"])
+        err = capsys.readouterr().err
+        assert "debug message" in err
+    finally:
+        for h in old_handlers:
+            root.addHandler(h)
+        root.setLevel(old_level)

--- a/twin_generator/cli.py
+++ b/twin_generator/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import sys
 from pathlib import Path
@@ -53,6 +54,8 @@ def _parse_cli(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: D4
 
 def main(argv: list[str] | None = None) -> None:  # noqa: D401 – imperative mood
     ns = _parse_cli(argv)
+
+    logging.basicConfig(level=logging.DEBUG if ns.verbose else logging.WARNING)
 
     if ns.demo or ns.graph_demo:
         problem_text: str = C._GRAPH_PROBLEM if ns.graph_demo else C._DEMO_PROBLEM


### PR DESCRIPTION
## Summary
- configure root logging in CLI so debug messages are emitted when --verbose is used
- add regression test ensuring verbose mode outputs debug logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2ddca225c833088b8dd7ea916972b