### PR TITLE
Refactor pipeline to use PipelineState dataclass

### DIFF
--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,5 +1,6 @@
 import logging
 from twin_generator import cli
+from twin_generator.pipeline import PipelineState
 
 def test_verbose_emits_logs(monkeypatch, capsys):
     root = logging.getLogger()
@@ -11,7 +12,7 @@ def test_verbose_emits_logs(monkeypatch, capsys):
 
     def fake_generate_twin(*args, **kwargs):
         logging.getLogger().debug("debug message")
-        return {}
+        return PipelineState()
 
     monkeypatch.setattr(cli, "generate_twin", fake_generate_twin)
     try:

--- a/tests/test_json_enforcement.py
+++ b/tests/test_json_enforcement.py
@@ -67,4 +67,4 @@ def test_generate_twin_invalid_json(monkeypatch: pytest.MonkeyPatch, bad_agent: 
     monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
 
     out = pipeline.generate_twin("p", "s")
-    assert out.get("error", "").startswith(f"{bad_agent} failed:")
+    assert out.error is not None and out.error.startswith(f"{bad_agent} failed:")

--- a/twin_generator/cli.py
+++ b/twin_generator/cli.py
@@ -7,10 +7,10 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from dataclasses import asdict
 
 from . import constants as C
-from .pipeline import generate_twin
+from .pipeline import PipelineState, generate_twin
 
 __all__ = ["main"]
 
@@ -69,7 +69,7 @@ def main(argv: list[str] | None = None) -> None:  # noqa: D401 – imperative m
     if "OPENAI_API_KEY" not in os.environ:
         sys.exit("Error: Set OPENAI_API_KEY before running.")
 
-    out: dict[str, Any] = generate_twin(
+    out: PipelineState = generate_twin(
         problem_text,
         solution_text,
         force_graph=bool(ns.graph_demo),
@@ -78,10 +78,10 @@ def main(argv: list[str] | None = None) -> None:  # noqa: D401 – imperative m
     )
 
     auto_preview = ns.preview or ns.graph_demo
-    if auto_preview and "graph_path" in out:
-        _preview_graph(str(out["graph_path"]))
+    if auto_preview and out.graph_path:
+        _preview_graph(str(out.graph_path))
 
-    json_out = json.dumps(out, ensure_ascii=False, separators=(",", ":"))
+    json_out = json.dumps(asdict(out), ensure_ascii=False, separators=(",", ":"))
     if ns.out:
         Path(ns.out).write_text(json_out, "utf-8")
         print(f"✔ Twin problem JSON written to {ns.out}")

--- a/twin_generator/pipeline.py
+++ b/twin_generator/pipeline.py
@@ -1,7 +1,7 @@
 """Linear pipeline orchestration of agents, tools, and helpers."""
 from __future__ import annotations
 
-from typing import Any, cast
+
 
 from agents.run import Runner as AgentsRunner  # type: ignore  # noqa: F401
 
@@ -19,6 +19,7 @@ from .agents import (  # noqa: F401
     SymbolicSimplifyAgent,
 )
 from .pipeline_runner import _Graph, _Runner
+from .pipeline_state import PipelineState
 from .pipeline_steps import (
     _step_answer,
     _step_concept,
@@ -40,7 +41,7 @@ from .pipeline_helpers import (  # noqa: F401
     invoke_agent,
 )
 
-__all__ = ["generate_twin"]
+__all__ = ["generate_twin", "PipelineState"]
 
 _PIPELINE = _Graph(
     steps=[
@@ -65,15 +66,14 @@ def generate_twin(
     force_graph: bool = False,
     graph_spec: GraphSpec | None = None,
     verbose: bool = False,
-) -> dict[str, Any]:  # noqa: ANN401 – generic return
+) -> PipelineState:
     """Generate a twin SAT-style math question given a source problem/solution."""
     runner = _Runner(_PIPELINE, verbose=verbose)
-    result = runner.run(
-        {
-            "problem_text": problem_text,
-            "solution": solution_text,
-            "force_graph": force_graph,
-            "graph_spec": graph_spec,
-        }
+    state = PipelineState(
+        problem_text=problem_text,
+        solution=solution_text,
+        force_graph=force_graph,
+        graph_spec=graph_spec,
     )
-    return cast(dict[str, Any], result["output"])
+    result = runner.run(state)
+    return result

--- a/twin_generator/pipeline_runner.py
+++ b/twin_generator/pipeline_runner.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
-from typing import Any, Callable
+import copy
+from dataclasses import asdict, dataclass
+from typing import Callable
 
 from .agents import QAAgent
 from .pipeline_helpers import AgentsRunner, _TOOLS
 from .utils import get_final_output
+from .pipeline_state import PipelineState
 
 
 @dataclass(slots=True)
 class _Graph:
-    steps: list[Callable[[dict[str, Any]], dict[str, Any]]]
+    steps: list[Callable[[PipelineState], PipelineState]]
 
 
 class _Runner:
@@ -33,30 +35,34 @@ class _Runner:
         self.logger.setLevel(logging.DEBUG if verbose else logging.WARNING)
 
     def _execute_step(
-        self, step: Callable[[dict[str, Any]], dict[str, Any]], data: dict[str, Any]
+        self,
+        step: Callable[[PipelineState], PipelineState],
+        data: PipelineState,
     ) -> tuple[
-        dict[str, Any],
+        PipelineState,
         bool,
-        list[Callable[[dict[str, Any]], dict[str, Any]]] | None,
-        dict[str, Any],
+        list[Callable[[PipelineState], PipelineState]] | None,
+        PipelineState,
     ]:
-        before = dict(data)
+        before = copy.deepcopy(data)
         result = step(data)
-        skip_qa = bool(result.pop("skip_qa", False))
-        next_steps = result.pop("next_steps", None)
+        skip_qa = bool(result.skip_qa)
+        next_steps = result.next_steps
+        result.skip_qa = False
+        result.next_steps = None
         return result, skip_qa, next_steps, before
 
     def _qa_check(
         self,
         name: str,
-        data: dict[str, Any],
+        data: PipelineState,
         idx: int,
         attempts: int,
         total_steps: int,
         json_required: bool,
     ) -> tuple[bool, str]:
         try:
-            qa_in = json.dumps({"step": name, "data": data})
+            qa_in = json.dumps({"step": name, "data": asdict(data)})
         except (TypeError, ValueError) as exc:
             if not json_required:
                 raise RuntimeError(f"QAAgent failed: {exc}")
@@ -85,8 +91,8 @@ class _Runner:
         )
         return qa_out == "pass", qa_out
 
-    def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        data = dict(inputs)
+    def run(self, inputs: PipelineState) -> PipelineState:
+        data = copy.deepcopy(inputs)
         steps = list(self.graph.steps)
         idx = 0
         while idx < len(steps):
@@ -102,8 +108,8 @@ class _Runner:
                     attempts + 1,
                 )
                 data, skip_qa, next_steps, before = self._execute_step(step, data)
-                if "error" in data:
-                    return {"output": data}
+                if data.error is not None:
+                    return data
                 if skip_qa:
                     if next_steps:
                         steps[idx + 1 : idx + 1] = next_steps
@@ -115,7 +121,8 @@ class _Runner:
                         name, data, idx, attempts, len(steps), json_required
                     )
                 except RuntimeError as exc:
-                    return {"output": {"error": str(exc)}}
+                    data.error = str(exc)
+                    return data
                 if passed:
                     if next_steps:
                         steps[idx + 1 : idx + 1] = next_steps
@@ -125,11 +132,8 @@ class _Runner:
                     self.qa_max_retries is not None
                     and attempts >= self.qa_max_retries
                 ):
-                    return {
-                        "output": {
-                            "error": f"QA failed for {name}: {qa_out}",
-                        }
-                    }
+                    data.error = f"QA failed for {name}: {qa_out}"
+                    return data
                 data = before
             idx += 1
-        return {"output": data}
+        return data

--- a/twin_generator/pipeline_state.py
+++ b/twin_generator/pipeline_state.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .constants import GraphSpec
+
+
+@dataclass
+class PipelineState:
+    """Typed container for data flowing through the pipeline."""
+
+    # Inputs
+    problem_text: str = ""
+    solution: str = ""
+    force_graph: bool = False
+    graph_spec: GraphSpec | None = None
+
+    # Intermediate results
+    parsed: dict[str, Any] | None = None
+    concept: str | None = None
+    template: dict[str, Any] | None = None
+    params: dict[str, Any] | None = None
+    symbolic_solution: str | None = None
+    symbolic_simplified: str | None = None
+    symbolic_error: str | None = None
+    graph_path: str | None = None
+    table_html: str | None = None
+    answer: Any | None = None
+    stem_data: dict[str, Any] | None = None
+
+    # Final formatted output fields
+    twin_stem: str | None = None
+    choices: list[Any] | None = None
+    answer_index: int | None = None
+    answer_value: Any | None = None
+    rationale: str | None = None
+    errors: list[str] | None = None
+
+    # Error handling
+    error: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    # Runner metadata
+    skip_qa: bool = False
+    next_steps: list[Callable[["PipelineState"], "PipelineState"]] | None = None


### PR DESCRIPTION
## Summary
- add `PipelineState` dataclass encapsulating pipeline data
- refactor pipeline runner and steps to operate on `PipelineState`
- update CLI and tests for new pipeline state API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e906ea588330b2e93d1502f56549