### PR TITLE
Add log-level flag and info-level logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ python -m twin_generator.cli --problem path/to/problem.txt --solution path/to/so
 python -m twin_generator.cli --demo
 ```
 
-Passing `--graph-demo` runs a demo that produces a graph visual. Append `--preview` to automatically preview the generated graph if any. Use `--verbose` to see each pipeline step.
+Passing `--graph-demo` runs a demo that produces a graph visual. Append `--preview` to automatically preview the generated graph if any. Use `--log-level INFO` (or `DEBUG`) to see each pipeline step.
 
 ## Tool annotation support
 

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,24 +1,40 @@
 import logging
+from typing import Any
 from twin_generator import cli
 
-def test_verbose_emits_logs(monkeypatch, capsys):
+
+def test_log_level_is_isolated(monkeypatch: Any, capsys: Any) -> None:
     root = logging.getLogger()
     old_handlers = root.handlers[:]
     old_level = root.level
     for h in old_handlers:
         root.removeHandler(h)
+
+    pkg_logger = logging.getLogger("twin_generator")
+    pkg_old_handlers = pkg_logger.handlers[:]
+    pkg_old_level = pkg_logger.level
+    for h in pkg_old_handlers:
+        pkg_logger.removeHandler(h)
+
     monkeypatch.setenv("OPENAI_API_KEY", "test")
 
-    def fake_generate_twin(*args, **kwargs):
-        logging.getLogger().debug("debug message")
+    def fake_generate_twin(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        logging.getLogger().debug("root debug")
+        pkg_logger.debug("pkg debug")
         return {}
 
     monkeypatch.setattr(cli, "generate_twin", fake_generate_twin)
     try:
-        cli.main(["--demo", "--verbose"])
+        cli.main(["--demo", "--log-level", "DEBUG"])
         err = capsys.readouterr().err
-        assert "debug message" in err
+        assert "pkg debug" in err
+        assert "root debug" not in err
     finally:
         for h in old_handlers:
             root.addHandler(h)
         root.setLevel(old_level)
+        for h in pkg_logger.handlers[len(pkg_old_handlers):]:
+            pkg_logger.removeHandler(h)
+        for h in pkg_old_handlers:
+            pkg_logger.addHandler(h)
+        pkg_logger.setLevel(pkg_old_level)

--- a/twin_generator/pipeline_runner.py
+++ b/twin_generator/pipeline_runner.py
@@ -30,7 +30,7 @@ class _Runner:
         self.verbose = verbose
         self.qa_max_retries = qa_max_retries
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.DEBUG if verbose else logging.WARNING)
+        self.logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
     def _execute_step(
         self, step: Callable[[dict[str, Any]], dict[str, Any]], data: dict[str, Any]
@@ -61,7 +61,7 @@ class _Runner:
             if not json_required:
                 raise RuntimeError(f"QAAgent failed: {exc}")
             qa_out = f"non-serializable data: {exc}"
-            self.logger.debug(
+            self.logger.info(
                 "[twin-generator] step %d/%d: %s QA round %d: %s",
                 idx + 1,
                 total_steps,
@@ -75,7 +75,7 @@ class _Runner:
             qa_out = get_final_output(qa_res).strip().lower()
         except Exception as exc:  # pragma: no cover - defensive
             raise RuntimeError(f"QAAgent failed: {exc}")
-        self.logger.debug(
+        self.logger.info(
             "[twin-generator] step %d/%d: %s QA round %d: %s",
             idx + 1,
             total_steps,
@@ -94,7 +94,7 @@ class _Runner:
             name = step.__name__.replace("_step_", "").lstrip("_")
             attempts = 0
             while True:
-                self.logger.debug(
+                self.logger.info(
                     "[twin-generator] step %d/%d: %s attempt %d",
                     idx + 1,
                     len(steps),


### PR DESCRIPTION
## Summary
- use INFO-level logging for progress/QA messages in pipeline runner
- replace --verbose flag with configurable --log-level in CLI
- document new log-level flag and add isolation test

## Testing
- `pre-commit run --files README.md tests/test_cli_logging.py twin_generator/cli.py twin_generator/pipeline_runner.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3ea0aca38833084528a7745c7cf22