### PR TITLE
Handle lowercase MPLBACKEND in backend selection

### DIFF
--- a/tests/test_render_graph_backend.py
+++ b/tests/test_render_graph_backend.py
@@ -2,6 +2,7 @@ import json
 import importlib
 from pathlib import Path
 import sys
+from typing import Any
 
 import pytest
 
@@ -11,7 +12,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 
-def test_render_graph_headless_uses_agg(monkeypatch):
+def test_render_graph_headless_uses_agg(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DISPLAY", raising=False)
     monkeypatch.delenv("MPLBACKEND", raising=False)
 
@@ -27,14 +28,14 @@ def test_render_graph_headless_uses_agg(monkeypatch):
         Path(path).unlink(missing_ok=True)
 
 
-def test_missing_gui_backend_warns(monkeypatch):
-    monkeypatch.setenv("MPLBACKEND", "TkAgg")
+def test_missing_gui_backend_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MPLBACKEND", "tkagg")
     monkeypatch.delenv("DISPLAY", raising=False)
 
     import matplotlib
     original_use = matplotlib.use
 
-    def fail_use(backend, *args, **kwargs):
+    def fail_use(backend: str, *args: Any, **kwargs: Any) -> Any:
         if backend == "TkAgg":
             raise ImportError("TkAgg not available")
         return original_use(backend, *args, **kwargs)

--- a/twin_generator/tools.py
+++ b/twin_generator/tools.py
@@ -54,7 +54,8 @@ def _select_matplotlib_backend() -> None:
     if backend in {"agg", "tkagg"}:  # already configured
         return
 
-    prefer_tk = bool(os.environ.get("DISPLAY")) or os.environ.get("MPLBACKEND") == "TkAgg"
+    env_backend = os.environ.get("MPLBACKEND", "").lower()
+    prefer_tk = bool(os.environ.get("DISPLAY")) or env_backend == "tkagg"
     if prefer_tk:
         try:
             matplotlib.use("TkAgg")


### PR DESCRIPTION
## Summary
- make `_select_matplotlib_backend` honor lowercase `MPLBACKEND`
- test `tkagg` value is recognized when GUI backend is missing

## Testing
- `pre-commit run --files twin_generator/tools.py tests/test_render_graph_backend.py`
- `pytest tests/test_render_graph_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3f9fcce1083309ffa6da655cc03c7