### PR TITLE
Return copies of sanitized tools

### DIFF
--- a/agents/run.py
+++ b/agents/run.py
@@ -102,9 +102,13 @@ class Runner:
                 tool_map[name] = t
                 cached = cls._SANITIZED_CACHE.get(name)
                 if cached is None:
-                    cached = {k: v for k, v in t.items() if not k.startswith("_")}
-                    cls._SANITIZED_CACHE[name] = cached
-                sanitized.append(cached)
+                    sanitized_tool = {
+                        k: v for k, v in t.items() if not k.startswith("_")
+                    }
+                    cls._SANITIZED_CACHE[name] = sanitized_tool.copy()
+                    sanitized.append(sanitized_tool.copy())
+                else:
+                    sanitized.append(cached.copy())
             else:
                 sanitized.append({k: v for k, v in t.items() if not k.startswith("_")})
         return sanitized, tool_map

--- a/tests/test_runner_tools.py
+++ b/tests/test_runner_tools.py
@@ -25,7 +25,8 @@ def test_sanitize_tools_caches_by_name() -> None:
     sanitized1, _ = Runner._sanitize_tools([tool1])
     sanitized2, _ = Runner._sanitize_tools([tool2])
 
-    assert sanitized1[0] is sanitized2[0]
+    assert sanitized1[0] == sanitized2[0]
+    assert sanitized1[0] is not sanitized2[0]
 
 
 def test_execute_tool_calls_runs_tools_and_returns_response() -> None:


### PR DESCRIPTION
## Summary
- Ensure `_sanitize_tools` stores and returns copies to avoid mutating the cache
- Verify repeated sanitization uses cached data while yielding separate objects
- Adjust tests to check structural equality and object independence

## Testing
- `pre-commit run --files agents/run.py tests/test_runner_tools.py`
- `pytest tests/test_runner_tools.py -q`
- `pytest -q` *(fails: tests/test_cli_logging.py::test_log_level_is_isolated)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fa1129288330becca5672a9649ad