### PR TITLE
Fix JSON quote repair and add apostrophe test

### DIFF
--- a/tests/test_safe_json.py
+++ b/tests/test_safe_json.py
@@ -30,6 +30,11 @@ def test_safe_json_with_comments() -> None:
     assert out == {"a": 1, "b": 2}
 
 
+def test_safe_json_apostrophes_inside_strings() -> None:
+    out = safe_json("{'text': \"it's great\"}")
+    assert out == {"text": "it's great"}
+
+
 def test_safe_json_error_message() -> None:
     with pytest.raises(ValueError) as exc:
         safe_json("not json")

--- a/twin_generator/utils.py
+++ b/twin_generator/utils.py
@@ -44,7 +44,14 @@ def _extract_json_block(text: str) -> str:
 def _repair_json(text: str) -> str:
     """Attempt light‑weight JSON repairs and return the adjusted string."""
     repaired = text
-    repaired = re.sub(r"(?<!\\)'", '"', repaired)
+    # Replace only single quotes that act as string delimiters, leaving apostrophes
+    # inside strings intact. This pattern mirrors typical JSON token boundaries and
+    # avoids overzealous replacements.
+    repaired = re.sub(
+        r"(?<![\\w])'([^'\\]*(?:\\.[^'\\]*)*)'",
+        r'"\1"',
+        repaired,
+    )
     # Strip both line (`//`) and block (`/* */`) comments
     repaired = re.sub(r"//.*?(?=\n|$)", "", repaired)
     repaired = re.sub(r"/\*.*?\*/", "", repaired, flags=re.DOTALL)


### PR DESCRIPTION
## Summary
- refine JSON repair to only convert delimiter quotes and preserve apostrophes inside strings
- add regression test ensuring apostrophes survive safe_json repair

## Testing
- `pre-commit run --files twin_generator/utils.py tests/test_safe_json.py`
- `PYTHONPATH=. pytest tests/test_safe_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3fa27c0b08330b184b40b03670629