### PR TITLE
Clarify SampleAgent parameter requirements

### DIFF
--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -54,7 +54,10 @@ SampleAgent = Agent(
         "Given a parameterized math problem template, generate a candidate "
         "parameter set and compute output. Return only a single JSON object "
         "with double-quoted keys/values and no trailing text representing the "
-        "parameter mapping, ensuring coverage through extremely advanced math operations."
+        "parameter mapping. Only include numeric parameter values required by "
+        "the template—no extra commentary, derived objects, or additional fields. "
+        "Each parameter value must be a plain number or numeric expression "
+        "compatible with SymPy, ensuring coverage through extremely advanced math operations."
     ),
     model="gpt-5-mini",
 )


### PR DESCRIPTION
## Summary
- restrict SampleAgent to return only numeric parameter values required by the template
- require each parameter be a plain SymPy-compatible number or expression

## Testing
- `pre-commit run --files twin_generator/agents.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5398e63c08330952fc80a55e9dc2c