### PR TITLE
Handle optional json5 import for mypy

### DIFF
--- a/twin_generator/utils.py
+++ b/twin_generator/utils.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 import json
 import os
 import re
+from types import ModuleType
 from typing import Any, Callable, cast
 
 try:  # pragma: no cover - optional dependency
-    import json5  # type: ignore
+    import json5 as _json5  # type: ignore
 except Exception:  # pragma: no cover - fall back to stdlib
-    json5 = None
+    _json5 = None
+json5: ModuleType | None = _json5
 
 # ---------------------------------------------------------------------------
 # Generic agent output handling


### PR DESCRIPTION
## Summary
- type annotate optional `json5` import so mypy accepts fallback to standard JSON parser

## Testing
- `mypy twin_generator`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55882f4d0833086e71bff1c87c3ce