### PR TITLE
Handle invalid graph specs

### DIFF
--- a/twin_generator/pipeline_steps.py
+++ b/twin_generator/pipeline_steps.py
@@ -197,12 +197,18 @@ def _step_visual(state: PipelineState) -> PipelineState:
     vtype = visual.get("type")
     if vtype == "graph":
         spec = visual.get("data", {}) or C.DEFAULT_GRAPH_SPEC
-        state.graph_path = _render_graph(json.dumps(spec))
+        try:
+            state.graph_path = _render_graph(json.dumps(spec))
+        except Exception as exc:
+            state.error = f"Invalid graph spec: {exc}"
         return state
 
     if force:
         gspec = user_spec or C.DEFAULT_GRAPH_SPEC
-        state.graph_path = _render_graph(json.dumps(gspec))
+        try:
+            state.graph_path = _render_graph(json.dumps(gspec))
+        except Exception as exc:
+            state.error = f"Invalid graph spec: {exc}"
         return state
 
     if vtype == "table":


### PR DESCRIPTION
## Summary
- gracefully handle invalid graph specs in pipeline visual step
- test invalid graph specs set `state.error`

## Testing
- `pre-commit run --files twin_generator/pipeline_steps.py tests/test_pipeline.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55c573d548330b575f79ff1a3bf92