### PR TITLE
Validate graph point inputs before rendering

### DIFF
--- a/tests/test_render_graph_points.py
+++ b/tests/test_render_graph_points.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import twin_generator.tools as tools
+
+
+def test_render_graph_raises_for_insufficient_point_entries() -> None:
+    spec = json.dumps({"points": [[1]]})
+    with pytest.raises(ValueError, match=r"expected \[x, y\]"):
+        tools._render_graph(spec)
+
+
+def test_render_graph_truncates_extra_point_entries() -> None:
+    spec = json.dumps({"points": [[0, 1, 2], [2, 3, 4]]})
+    path = tools._render_graph(spec)
+    try:
+        assert Path(path).is_file()
+    finally:
+        Path(path).unlink(missing_ok=True)

--- a/twin_generator/tools.py
+++ b/twin_generator/tools.py
@@ -75,9 +75,30 @@ def _render_graph(spec_json: str) -> str:
     """Render a graph to a **PNG file** and return the file path (string)."""
     import matplotlib.pyplot as plt  # type: ignore
     spec = json.loads(spec_json)
-    points: list[list[float]] = spec.get("points", [])
+    raw_points: list[Any] = spec.get("points", [])
     style: str = spec.get("style", "line")
     title: str | None = spec.get("title")
+
+    # Validate and normalize points
+    points: list[tuple[float, float]] = []
+    for idx, pt in enumerate(raw_points):
+        if not isinstance(pt, (list, tuple)):
+            raise ValueError(
+                f"Point {idx} invalid: expected [x, y] format, got {pt!r}"
+            )
+        if len(pt) < 2:
+            raise ValueError(
+                f"Point {idx} invalid: expected [x, y] format, got {pt!r}"
+            )
+        x, y = pt[:2]
+        try:
+            x_f = float(x)
+            y_f = float(y)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"Point {idx} invalid: expected [x, y] format, got {pt!r}"
+            )
+        points.append((x_f, y_f))
 
     fig, ax = plt.subplots(figsize=(6, 6))
 


### PR DESCRIPTION
## Summary
- validate point entries in `_render_graph`, truncating extras and raising `ValueError` on malformed data
- add tests for insufficient and extra point entries

## Testing
- `pre-commit run --files twin_generator/tools.py tests/test_render_graph_points.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55c4c4dd08330a88f0f109082cd61