### PR TITLE
fix: annotate optional json5 import for mypy

### DIFF
--- a/twin_generator/utils.py
+++ b/twin_generator/utils.py
@@ -8,6 +8,7 @@ import re
 from types import ModuleType
 from typing import Any, Callable
 
+_json5: ModuleType | None
 try:  # pragma: no cover - optional dependency
     import json5 as _json5  # type: ignore
 except Exception:  # pragma: no cover - fall back to stdlib


### PR DESCRIPTION
## Summary
- annotate optional json5 import to handle missing dependency without mypy errors

## Testing
- `pre-commit run --files twin_generator/utils.py`
- `mypy twin_generator`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a560d0c1088330bc76358139cefaec