### PR TITLE
feat: support implicit multiplication and equations

### DIFF
--- a/tests/test_calc_answer.py
+++ b/tests/test_calc_answer.py
@@ -44,3 +44,11 @@ def test_calc_answer_timeout_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(tools, "_run_with_timeout", _timeout)
     assert tools._calc_answer("diff(x**2, x)", '{}') == "Derivative(x**2, x)"
+
+
+def test_calc_answer_implicit_multiplication() -> None:
+    assert _calc_answer("m x", '{"m": 3, "x": 4}') == 12
+
+
+def test_calc_answer_equation_rhs() -> None:
+    assert _calc_answer("y = m x", '{"m": 3, "x": 4}') == 12

--- a/twin_generator/tools/calc.py
+++ b/twin_generator/tools/calc.py
@@ -73,11 +73,18 @@ def _calc_answer(expression: str, params_json: str) -> Any:  # noqa: ANN401 â€“Â
         "Limit": _make_safe(lambda *a, **k: sp.Limit(*a, **k).doit(), sp.Limit),
         "Sum": _make_safe(lambda *a, **k: sp.Sum(*a, **k).doit(), sp.Sum),
     }
+    from sympy.parsing.sympy_parser import (
+        implicit_multiplication_application,
+        parse_expr,
+        standard_transformations,
+    )
 
+    expr_str = expression.split("=", 1)[1] if "=" in expression else expression
+    transformations = (*standard_transformations, implicit_multiplication_application)
     try:
-        expr = sp.sympify(expression, locals=local_ops)
+        expr = parse_expr(expr_str, local_dict=local_ops, transformations=transformations)
     except Exception:
-        expr = sp.sympify(expression)
+        expr = parse_expr(expr_str, transformations=transformations)
 
     def _eval_advanced(e: sp.Expr, depth: int = 0) -> sp.Expr:
         if depth > 5:


### PR DESCRIPTION
## Summary
- allow calc tool to parse equations and implicit multiplication using SymPy's parser
- test math expressions with space-separated factors and equation-style inputs

## Testing
- `pre-commit run --files twin_generator/tools/calc.py tests/test_calc_answer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5895223b88330baa8e98b18cd5252