### PR TITLE
Add tests for calc addition and friendly error handling

### DIFF
--- a/twin_generator/tools/calc.py
+++ b/twin_generator/tools/calc.py
@@ -90,7 +90,10 @@ def _calc_answer(expression: str, params_json: str) -> Any:  # noqa: ANN401 â€“Â
     try:
         expr = parse_expr(expr_str, local_dict=local_ops, transformations=transformations)
     except Exception:
-        expr = parse_expr(expr_str, transformations=transformations)
+        try:
+            expr = parse_expr(expr_str, transformations=transformations)
+        except Exception as exc:
+            raise ValueError(error_msg) from exc
 
     if isinstance(expr, Relational):
         raise ValueError(error_msg)


### PR DESCRIPTION
## Summary
- handle malformed expressions in `_calc_answer` with a user-friendly `ValueError`
- test equation `y = m x + b` evaluates to 11
- test malformed expressions and timeout fallbacks raise the friendly error

## Testing
- `python -m pre_commit run --files twin_generator/tools/calc.py tests/test_calc_answer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a69c609fe08330afe74bc5b5ebc23d