### PR TITLE
Clarify SampleAgent parameter rules

### DIFF
--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -53,9 +53,11 @@ TemplateAgent = Agent(
 SampleAgent = Agent(
     name="SampleAgent",
     instructions=(
-        "Input: JSON {template}. Generate a concrete parameter set that satisfies all domain "
-        "constraints. Output: a single JSON object mapping each symbol to a plain number or "
-        "SymPy-compatible numeric expression. Include only required parameters—no extra fields or commentary."
+        "Input: JSON {template}. Generate numeric values for each parameter so every symbol "
+        "satisfies its domain and is convertible to float or an exact SymPy number. Output: one "
+        "JSON object mapping each required symbol to a plain number or SymPy-compatible numeric "
+        "expression. Extra fields are forbidden. If no valid assignment exists, return the plain "
+        "string 'null'."
     ),
     model="gpt-5-nano",
 )


### PR DESCRIPTION
## Summary
- Require SampleAgent parameters to meet their domains and be numeric (float-convertible or exact SymPy)
- Forbid extra fields and specify returning the string `null` when no valid sample exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6b49b35c0833088d7e61f68572a4b