### PR TITLE
Add QA helper tools

### DIFF
--- a/twin_generator/pipeline_helpers.py
+++ b/twin_generator/pipeline_helpers.py
@@ -8,6 +8,11 @@ from agents.run import Runner as AgentsRunner  # type: ignore
 from .tools.calc import calc_answer_tool
 from .tools.graph import render_graph_tool
 from .tools.html_table import make_html_table_tool
+from .tools.qa_tools import (
+    check_asset_tool,
+    sanitize_params_tool,
+    validate_output_tool,
+)
 from .utils import get_final_output, safe_json
 
 __all__ = [
@@ -23,7 +28,14 @@ __all__ = [
 # Default tools available to most agents. TemplateAgent is intentionally given a
 # more restrictive list that excludes ``render_graph_tool`` and
 # ``make_html_table_tool``.
-_TOOLS = [calc_answer_tool, render_graph_tool, make_html_table_tool]
+_TOOLS = [
+    calc_answer_tool,
+    render_graph_tool,
+    make_html_table_tool,
+    sanitize_params_tool,
+    validate_output_tool,
+    check_asset_tool,
+]
 _TEMPLATE_TOOLS = [calc_answer_tool]
 _TEMPLATE_MAX_RETRIES = 3
 _JSON_MAX_RETRIES = 3

--- a/twin_generator/tools/__init__.py
+++ b/twin_generator/tools/__init__.py
@@ -3,12 +3,26 @@
 from .html_table import _make_html_table, make_html_table_tool
 from .graph import _render_graph, render_graph_tool
 from .calc import _calc_answer, calc_answer_tool
+from .qa_tools import (
+    _check_asset,
+    _sanitize_params_tool,
+    _validate_output_tool,
+    check_asset_tool,
+    sanitize_params_tool,
+    validate_output_tool,
+)
 
 __all__ = [
     "make_html_table_tool",
     "render_graph_tool",
     "calc_answer_tool",
+    "sanitize_params_tool",
+    "validate_output_tool",
+    "check_asset_tool",
     "_make_html_table",
     "_render_graph",
     "_calc_answer",
+    "_sanitize_params_tool",
+    "_validate_output_tool",
+    "_check_asset",
 ]

--- a/twin_generator/tools/qa_tools.py
+++ b/twin_generator/tools/qa_tools.py
@@ -1,0 +1,53 @@
+"""QA-specific tool wrappers."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from agents.tool import function_tool
+
+from .calc import _sanitize_params
+from ..utils import coerce_answers, validate_output
+
+__all__ = [
+    "sanitize_params_tool",
+    "validate_output_tool",
+    "check_asset_tool",
+    "_sanitize_params_tool",
+    "_validate_output_tool",
+    "_check_asset",
+]
+
+
+def _sanitize_params_tool(params_json: str) -> dict[str, Any]:
+    """Return numeric parameters and skipped keys from *params_json*."""
+    params = json.loads(params_json)
+    sanitized, skipped = _sanitize_params(params)
+    sanitized_out = {k: str(v) for k, v in sanitized.items()}
+    return {"sanitized": sanitized_out, "skipped": skipped}
+
+
+sanitize_params_tool = function_tool(_sanitize_params_tool)
+
+
+def _validate_output_tool(block_json: str) -> dict[str, Any]:
+    """Coerce answer fields then validate the formatter output."""
+    block = json.loads(block_json)
+    block = coerce_answers(block)
+    return validate_output(block)
+
+
+validate_output_tool = function_tool(_validate_output_tool)
+
+
+def _check_asset(graph_path: str | None = None, table_html: str | None = None) -> bool:
+    """Return ``True`` if ``graph_path`` exists or ``table_html`` is present."""
+    if graph_path and os.path.isfile(graph_path):
+        return True
+    if table_html and str(table_html).strip():
+        return True
+    return False
+
+
+check_asset_tool = function_tool(_check_asset)


### PR DESCRIPTION
## Summary
- add qa-specific tool wrappers for sanitizing params, validating output, and verifying assets
- expose QA tools via tools package and register them with pipeline helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6f999ab908330bd9d7356f39ee890