### PR TITLE
Provide QA tooling and guidance for QA agent

### DIFF
--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -97,10 +97,14 @@ FormatterAgent = Agent(
 QAAgent = Agent(
     name="QAAgent",
     instructions=(
-        "Input: JSON {\"step\": <name>, \"data\": <PipelineState>}. First ensure the JSON is syntactically valid. "
-        "Then verify that every field required for the named pipeline step exists and that all values are internally "
-        "consistent—indices align with arrays, assets exist, and constraints are met. Output only the string 'pass' when "
-        "all checks succeed; otherwise return a concise reason for failure."
+        "Input: JSON {\"step\": <name>, \"data\": <PipelineState>}. First ensure the JSON is "
+        "syntactically valid. Use sanitize_params_tool to check numeric params and report skipped "
+        "keys. Invoke validate_output_tool to coerce answers and confirm formatter output. When "
+        "graph_path or table_html is present, call check_asset_tool to verify the asset exists. "
+        "Then verify that every field required for the named pipeline step exists and that all "
+        "values are internally consistent—indices align with arrays, assets exist, and constraints "
+        "are met. Output only the string 'pass' when all checks succeed; otherwise return a concise "
+        "reason for failure."
     ),
     model="gpt-5-nano",
 )
@@ -126,12 +130,17 @@ SymbolicSolveAgent = Agent(
 SymbolicSimplifyAgent = Agent(
     name="SymbolicSimplifyAgent",
     instructions=(
-        "Input: ONE SymPy expression STRING. Output: ONE SymPy expression STRING that is mathematically equivalent and simpler. "
-        "If no provable simplification exists, return the original input expression unchanged. Use exact arithmetic; no floats. "
-        "Enforce deterministic ordering of all symbols and terms. Preserve correctness on the default real domain unless the expression dictates otherwise. "
-        "Never perform domain-sensitive transformations without proof: do not cancel factors that may be zero, and do not combine logs or manipulate Abs unless argument positivity is guaranteed. "
-        "Avoid gratuitous expansion; keep structured forms unless expansion clearly simplifies. Respect principal branches for roots and Abs; introduce Piecewise only when needed and merge adjacent intervals/guards. "
-        "Return only the final expression with no commentary."
+        "Input: ONE SymPy expression STRING. Output: ONE SymPy expression STRING that is "
+        "mathematically equivalent and simpler. If no provable simplification exists, return "
+        "the original input expression unchanged. Use exact arithmetic; no floats. Enforce "
+        "deterministic ordering of all symbols and terms. Preserve correctness on the default "
+        "real domain unless the expression dictates otherwise. Never perform domain-sensitive "
+        "transformations without proof: do not cancel factors that may be zero, and do not "
+        "combine logs or manipulate Abs unless argument positivity is guaranteed. Avoid "
+        "gratuitous expansion; keep structured forms unless expansion clearly simplifies. "
+        "Respect principal branches for roots and Abs; introduce Piecewise only when needed "
+        "and merge adjacent intervals/guards. Return only the final expression with no "
+        "commentary."
     ),
     model="gpt-5-nano",
 )

--- a/twin_generator/pipeline_helpers.py
+++ b/twin_generator/pipeline_helpers.py
@@ -19,6 +19,7 @@ __all__ = [
     "AgentsRunner",
     "invoke_agent",
     "_TOOLS",
+    "_QA_TOOLS",
     "_TEMPLATE_TOOLS",
     "_TEMPLATE_MAX_RETRIES",
     "_JSON_MAX_RETRIES",
@@ -32,6 +33,11 @@ _TOOLS = [
     calc_answer_tool,
     render_graph_tool,
     make_html_table_tool,
+]
+
+# QAAgent also needs sanitization and output validation helpers.
+_QA_TOOLS = [
+    *_TOOLS,
     sanitize_params_tool,
     validate_output_tool,
     check_asset_tool,

--- a/twin_generator/pipeline_runner.py
+++ b/twin_generator/pipeline_runner.py
@@ -8,7 +8,7 @@ from dataclasses import asdict, dataclass
 from typing import Callable
 
 from .agents import QAAgent
-from .pipeline_helpers import AgentsRunner, _TOOLS
+from .pipeline_helpers import AgentsRunner, _QA_TOOLS
 from .utils import get_final_output
 from .pipeline_state import PipelineState
 
@@ -80,7 +80,7 @@ class _Runner:
             )
             return False, qa_out
         try:
-            qa_res = AgentsRunner.run_sync(QAAgent, input=qa_in, tools=_TOOLS)
+            qa_res = AgentsRunner.run_sync(QAAgent, input=qa_in, tools=_QA_TOOLS)
             qa_out = get_final_output(qa_res).strip().lower()
         except Exception as exc:  # pragma: no cover - defensive
             raise RuntimeError(f"QAAgent failed: {exc}")


### PR DESCRIPTION
## Summary
- isolate general agent tools from QA helpers and expose `_QA_TOOLS`
- use QA tool set when running QAAgent
- expand QAAgent instructions with guidance on sanitize/validate/asset tools

## Testing
- `pre-commit run --files twin_generator/agents.py twin_generator/pipeline_helpers.py twin_generator/pipeline_runner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6fe9c86b083308b91e647981ab467