### PR TITLE
Add symbolic solver tool for OperationsAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ Intermediate fields such as `parsed`, `concept`, `template`, `params`, `symbolic
 - **Tools** – Use [`agents.tool.function_tool`](agents/tool.py) to expose a Python function as a callable tool. Type hints are converted into the JSON schema understood by OpenAI's tool‑calling interface.
 - **Templates** – See [`docs/template_agent.md`](docs/template_agent.md) for the JSON schema produced by the `TemplateAgent`.
 
+### OperationsAgent
+
+Each item in the `operations` array may call a registered tool by including a
+`"tool"` field.  The newly added `symbolic_solve_tool` finds exact solutions to
+symbolic equations using SymPy.
+
+```json
+{
+  "tool": "symbolic_solve_tool",
+  "eq_json": "{\"equation\": \"x**2 - 1\", \"variable\": \"x\"}",
+  "output": "roots"
+}
+```
+
+The `eq_json` string must encode an object with `equation` (the equation or
+expression, optional `=` sign allowed) and `variable` (single symbol name or
+array of names). The tool returns a JSON array of solution dictionaries with
+simplified expressions.
+
 You can register additional tools or swap out agents to customize the pipeline for different domains.
 
 ## Development

--- a/twin_generator/pipeline_helpers.py
+++ b/twin_generator/pipeline_helpers.py
@@ -8,6 +8,7 @@ from agents.run import Runner as AgentsRunner  # type: ignore
 from .tools.calc import calc_answer_tool
 from .tools.graph import render_graph_tool
 from .tools.html_table import make_html_table_tool
+from .tools.symbolic_solve import symbolic_solve_tool
 from .tools.qa_tools import (
     check_asset_tool,
     sanitize_params_tool,
@@ -33,6 +34,7 @@ _TOOLS = [
     calc_answer_tool,
     render_graph_tool,
     make_html_table_tool,
+    symbolic_solve_tool,
 ]
 
 # QAAgent also needs sanitization and output validation helpers.

--- a/twin_generator/tools/__init__.py
+++ b/twin_generator/tools/__init__.py
@@ -11,6 +11,7 @@ from .qa_tools import (
     sanitize_params_tool,
     validate_output_tool,
 )
+from .symbolic_solve import _symbolic_solve, symbolic_solve_tool
 
 __all__ = [
     "make_html_table_tool",
@@ -19,10 +20,12 @@ __all__ = [
     "sanitize_params_tool",
     "validate_output_tool",
     "check_asset_tool",
+    "symbolic_solve_tool",
     "_make_html_table",
     "_render_graph",
     "_calc_answer",
     "_sanitize_params_tool",
     "_validate_output_tool",
     "_check_asset",
+    "_symbolic_solve",
 ]

--- a/twin_generator/tools/symbolic_solve.py
+++ b/twin_generator/tools/symbolic_solve.py
@@ -1,0 +1,64 @@
+"""Symbolic equation solver tool."""
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from agents.tool import function_tool
+
+__all__ = ["symbolic_solve_tool", "_symbolic_solve"]
+
+
+def _parse_equation(expr: str) -> Any:
+    import sympy as sp
+
+    if "=" in expr:
+        lhs, rhs = expr.split("=", 1)
+        return sp.Eq(sp.sympify(lhs), sp.sympify(rhs))
+    return sp.Eq(sp.sympify(expr), 0)
+
+
+def _to_symbols(sym: Any) -> Iterable[Any]:
+    import sympy as sp
+
+    if isinstance(sym, (list, tuple)):
+        return sp.symbols(list(sym))
+    return (sp.Symbol(sym),)
+
+
+def _symbolic_solve(eq_json: str) -> str:
+    """Return exact solution(s) to a symbolic equation.
+
+    Parameters
+    ----------
+    eq_json:
+        JSON string with two fields:
+        - ``equation``: a SymPy-readable expression. An ``=`` sign may be
+          provided; otherwise the expression is assumed to equal 0.
+        - ``variable``: single symbol name or list of names to solve for.
+
+    Returns
+    -------
+    str
+        JSON string encoding a list of solution dictionaries with simplified
+        expressions as strings.
+    """
+    import sympy as sp
+
+    payload = json.loads(eq_json)
+    eq_field = payload["equation"]
+    var_field = payload["variable"]
+
+    equations = [_parse_equation(eq_field)] if isinstance(eq_field, str) else [
+        _parse_equation(e) for e in eq_field
+    ]
+    symbols = _to_symbols(var_field)
+
+    solutions = sp.solve(equations, symbols, dict=True)
+    simplified = [
+        {str(k): str(sp.simplify(v)) for k, v in sol.items()} for sol in solutions
+    ]
+    return json.dumps(simplified)
+
+
+symbolic_solve_tool = function_tool(_symbolic_solve)


### PR DESCRIPTION
## Summary
- add `symbolic_solve_tool` using SymPy to produce exact solutions from JSON‑encoded equations
- expose tool from `twin_generator.tools` and register it in the default tool list
- document `OperationsAgent` use of `tool="symbolic_solve_tool"` and its input schema

## Testing
- `pre-commit run --files twin_generator/tools/symbolic_solve.py twin_generator/tools/__init__.py twin_generator/pipeline_helpers.py README.md`
- `mypy --config-file=mypy.ini twin_generator`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7c5b80d6c8330930546cbce0cd6e9