### PR TITLE
test: cover QAAgent tool flows

### DIFF
--- a/tests/test_runner_serialization.py
+++ b/tests/test_runner_serialization.py
@@ -13,6 +13,14 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import twin_generator.pipeline as pipeline  # noqa: E402
 
 
+def _qa_response(out: str, tools: Any | None) -> SimpleNamespace:
+    tool_map = {t["name"]: t for t in (tools or [])}
+    func = tool_map.get("_sanitize_params_tool", {}).get("_func")
+    if func:
+        func("{}")
+    return SimpleNamespace(final_output=out)
+
+
 @pytest.mark.parametrize("always_fail", [False, True])
 def test_runner_handles_non_serializable(monkeypatch: pytest.MonkeyPatch, always_fail: bool) -> None:
     """_Runner should retry steps producing non-serializable data and surface errors."""
@@ -27,7 +35,7 @@ def test_runner_handles_non_serializable(monkeypatch: pytest.MonkeyPatch, always
                 return SimpleNamespace(final_output={1})  # not JSON serializable
             return SimpleNamespace(final_output={"ok": 1})
         if name == "QAAgent":
-            return SimpleNamespace(final_output="pass")
+            return _qa_response("pass", tools)
         raise AssertionError(f"unexpected agent {name}")
 
     monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
@@ -42,7 +50,9 @@ def test_runner_handles_non_serializable(monkeypatch: pytest.MonkeyPatch, always
     runner = pipeline._Runner(pipeline._Graph([_step_bad]), qa_max_retries=2)
     out = runner.run(pipeline.PipelineState())
     if always_fail:
-        assert out.error.startswith("QA failed for bad: non-serializable")
+        assert out.error is not None and out.error.startswith(
+            "QA failed for bad: non-serializable"
+        )
         assert call_counts.get("ParserAgent") == 2
         assert call_counts.get("QAAgent") is None
     else:


### PR DESCRIPTION
## Summary
- mock QAAgent tool usage in existing tests
- add tests for invalid params, output mismatches, and missing assets

## Testing
- `pre-commit run --files tests/test_pipeline.py tests/test_json_enforcement.py tests/test_runner_serialization.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7d226c45483309240c921f87d8b43