### PR TITLE
Add tool reference documentation for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Intermediate fields such as `parsed`, `concept`, `template`, `params`, `symbolic
 ## Extending the System
 
 - **Agents** – Agent definitions live in [`twin_generator/agents.py`](twin_generator/agents.py). Each agent specifies a name, prompt instructions, and optional model.
-- **Tools** – Use [`agents.tool.function_tool`](agents/tool.py) to expose a Python function as a callable tool. Type hints are converted into the JSON schema understood by OpenAI's tool‑calling interface.
+- **Tools** – Use [`agents.tool.function_tool`](agents/tool.py) to expose a Python function as a callable tool. Type hints are converted into the JSON schema understood by OpenAI's tool‑calling interface. See [`docs/tools.md`](docs/tools.md) for available tools; agents should review it before invoking any tool.
 - **Templates** – See [`docs/template_agent.md`](docs/template_agent.md) for the JSON schema produced by the `TemplateAgent`.
 
 ### OperationsAgent

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,25 @@
+# Available Tools
+
+Agents must read this document before calling any tool.
+
+## calc_answer_tool
+Evaluates a mathematical expression with given parameters using SymPy. Use for exact numeric computation of expressions and intermediate results.
+
+## render_graph_tool
+Renders a graph described by a JSON specification to a PNG file and returns the file path. Use when a problem requires a plotted graph visual.
+
+## make_html_table_tool
+Converts a JSON table specification into an HTML `<table>` string with escaped values. Use to generate table visuals for problems.
+
+## sanitize_params_tool
+Sanitizes a JSON mapping of parameters, keeping only those convertible to numeric SymPy expressions and reporting skipped keys. Use for parameter validation.
+
+## validate_output_tool
+Coerces answer fields and validates the formatter output for structural consistency. Use in QA steps to ensure final JSON correctness.
+
+## check_asset_tool
+Verifies that a referenced graph file exists or that table HTML is non-empty. Use to confirm generated assets are present.
+
+## symbolic_solve_tool
+Solves symbolic equations for specified variables and returns simplified solutions as JSON. Use to obtain exact symbolic results within operations.
+

--- a/twin_generator/agents.py
+++ b/twin_generator/agents.py
@@ -98,13 +98,13 @@ QAAgent = Agent(
     name="QAAgent",
     instructions=(
         "Input: JSON {\"step\": <name>, \"data\": <PipelineState>}. First ensure the JSON is "
-        "syntactically valid. Use sanitize_params_tool to check numeric params and report skipped "
-        "keys. Invoke validate_output_tool to coerce answers and confirm formatter output. When "
-        "graph_path or table_html is present, call check_asset_tool to verify the asset exists. "
-        "Then verify that every field required for the named pipeline step exists and that all "
-        "values are internally consistent—indices align with arrays, assets exist, and constraints "
-        "are met. Output only the string 'pass' when all checks succeed; otherwise return a concise "
-        "reason for failure."
+        "syntactically valid. Consult docs/tools.md for tool behavior before invoking any. Use "
+        "sanitize_params_tool to check numeric params and report skipped keys. Invoke "
+        "validate_output_tool to coerce answers and confirm formatter output. When graph_path or "
+        "table_html is present, call check_asset_tool to verify the asset exists. Then verify that "
+        "every field required for the named pipeline step exists and that all values are internally "
+        "consistent—indices align with arrays, assets exist, and constraints are met. Output only "
+        "the string 'pass' when all checks succeed; otherwise return a concise reason for failure."
     ),
     model="gpt-5-nano",
 )
@@ -148,7 +148,9 @@ SymbolicSimplifyAgent = Agent(
 OperationsAgent = Agent(
     name="OperationsAgent",
     instructions=(
-        "Input: JSON {data: {...}, operations: [...]}. Each operation is an object with: "
+        "Input: JSON {data: {...}, operations: [...]}. Review docs/tools.md to understand available tools "
+        "before executing any operation. "
+        "Each operation is an object with: "
         "expr – an expression using fields from data or prior outputs; optional tool – the name of a registered tool; "
         "output (single key) or outputs (array of keys) naming where results should be stored; "
         "and any additional fields that reference entries in data or earlier outputs. "


### PR DESCRIPTION
## Summary
- document all exported tools in new `docs/tools.md`
- link tool reference from README's Extending the System section
- instruct QAAgent and OperationsAgent to consult tool docs before invoking tools

## Testing
- `pre-commit run --files README.md twin_generator/agents.py docs/tools.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a81482e078833090e79af10a085f51