### PR TITLE
Serialize tool outputs as JSON

### DIFF
--- a/agents/run.py
+++ b/agents/run.py
@@ -145,7 +145,7 @@ class Runner:
                         f"tool {name} provided invalid JSON arguments: {e}"
                     ) from e
                 result = func(**args)
-                outputs.append({"tool_call_id": call.id, "output": str(result)})
+                outputs.append({"tool_call_id": call.id, "output": json.dumps(result, default=str)})
             resp = client.responses.submit_tool_outputs(
                 response_id=resp.id, tool_outputs=outputs
             )


### PR DESCRIPTION
## Summary
- ensure tool call results are serialized to valid JSON using `json.dumps`

## Testing
- `pre-commit run --files agents/run.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a815210e48833083021d10304a15f4