### PR TITLE
Expose public tool names in generator

### DIFF
--- a/tests/test_json_enforcement.py
+++ b/tests/test_json_enforcement.py
@@ -16,7 +16,7 @@ import twin_generator.pipeline as pipeline  # noqa: E402
 def _qa_response(out: str, tools: Any | None) -> SimpleNamespace:
     """Simulate QAAgent using tools before returning *out*."""
     tool_map = {t["name"]: t for t in (tools or [])}
-    func = tool_map.get("_sanitize_params_tool", {}).get("_func")
+    func = tool_map.get("sanitize_params_tool", {}).get("_func")
     if func:
         func("{}")
     return SimpleNamespace(final_output=out)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,7 +19,7 @@ from twin_generator.constants import GraphSpec  # noqa: E402
 def _qa_response(out: str, tools: Any | None) -> SimpleNamespace:
     """Simulate QAAgent using its tools before returning *out*."""
     tool_map = {t["name"]: t for t in (tools or [])}
-    func = tool_map.get("_sanitize_params_tool", {}).get("_func")
+    func = tool_map.get("sanitize_params_tool", {}).get("_func")
     if func:
         func("{}")
     return SimpleNamespace(final_output=out)
@@ -653,7 +653,7 @@ def test_qa_detects_invalid_params(monkeypatch: pytest.MonkeyPatch) -> None:
             payload = json.loads(input)
             params = payload["data"].get("params", {})
             tool_map = {t["name"]: t for t in (tools or [])}
-            res = tool_map["_sanitize_params_tool"]["_func"](json.dumps(params))
+            res = tool_map["sanitize_params_tool"]["_func"](json.dumps(params))
             if res["skipped"]:
                 return SimpleNamespace(final_output="invalid params")
             return SimpleNamespace(final_output="pass")
@@ -684,7 +684,7 @@ def test_qa_detects_output_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
         if name == "QAAgent":
             payload = json.loads(input)
             tool_map = {t["name"]: t for t in (tools or [])}
-            res = tool_map["_validate_output_tool"]["_func"](json.dumps(payload["data"]))
+            res = tool_map["validate_output_tool"]["_func"](json.dumps(payload["data"]))
             if res.get("errors"):
                 return SimpleNamespace(final_output="output mismatch")
             return SimpleNamespace(final_output="pass")
@@ -716,7 +716,7 @@ def test_qa_detects_missing_asset(monkeypatch: pytest.MonkeyPatch) -> None:
             payload = json.loads(input)
             data = payload["data"]
             tool_map = {t["name"]: t for t in (tools or [])}
-            ok = tool_map["_check_asset"]["_func"](
+            ok = tool_map["check_asset_tool"]["_func"](
                 data.get("graph_path"), data.get("table_html")
             )
             return SimpleNamespace(final_output="pass" if ok else "missing asset")

--- a/tests/test_runner_serialization.py
+++ b/tests/test_runner_serialization.py
@@ -15,7 +15,7 @@ import twin_generator.pipeline as pipeline  # noqa: E402
 
 def _qa_response(out: str, tools: Any | None) -> SimpleNamespace:
     tool_map = {t["name"]: t for t in (tools or [])}
-    func = tool_map.get("_sanitize_params_tool", {}).get("_func")
+    func = tool_map.get("sanitize_params_tool", {}).get("_func")
     if func:
         func("{}")
     return SimpleNamespace(final_output=out)

--- a/twin_generator/tools/calc.py
+++ b/twin_generator/tools/calc.py
@@ -146,5 +146,5 @@ def _calc_answer(expression: str, params_json: str) -> Any:  # noqa: ANN401 â€“Â
     except Exception:
         raise ValueError(error_msg)
 
-
 calc_answer_tool = function_tool(_calc_answer)
+calc_answer_tool["name"] = "calc_answer_tool"

--- a/twin_generator/tools/graph.py
+++ b/twin_generator/tools/graph.py
@@ -116,5 +116,5 @@ def _render_graph(spec_json: str) -> str:
     plt.close(fig)
     return str(png_path)
 
-
 render_graph_tool = function_tool(_render_graph)
+render_graph_tool["name"] = "render_graph_tool"

--- a/twin_generator/tools/html_table.py
+++ b/twin_generator/tools/html_table.py
@@ -22,5 +22,5 @@ def _make_html_table(table_json: str) -> str:
     )
     return f"<table><thead><tr>{head_html}</tr></thead><tbody>{rows_html}</tbody></table>"
 
-
 make_html_table_tool = function_tool(_make_html_table)
+make_html_table_tool["name"] = "make_html_table_tool"

--- a/twin_generator/tools/qa_tools.py
+++ b/twin_generator/tools/qa_tools.py
@@ -29,6 +29,7 @@ def _sanitize_params_tool(params_json: str) -> dict[str, Any]:
 
 
 sanitize_params_tool = function_tool(_sanitize_params_tool)
+sanitize_params_tool["name"] = "sanitize_params_tool"
 
 
 def _validate_output_tool(block_json: str) -> dict[str, Any]:
@@ -39,6 +40,7 @@ def _validate_output_tool(block_json: str) -> dict[str, Any]:
 
 
 validate_output_tool = function_tool(_validate_output_tool)
+validate_output_tool["name"] = "validate_output_tool"
 
 
 def _check_asset(graph_path: str | None = None, table_html: str | None = None) -> bool:
@@ -51,3 +53,4 @@ def _check_asset(graph_path: str | None = None, table_html: str | None = None) -
 
 
 check_asset_tool = function_tool(_check_asset)
+check_asset_tool["name"] = "check_asset_tool"

--- a/twin_generator/tools/symbolic_solve.py
+++ b/twin_generator/tools/symbolic_solve.py
@@ -60,5 +60,5 @@ def _symbolic_solve(eq_json: str) -> str:
     ]
     return json.dumps(simplified)
 
-
 symbolic_solve_tool = function_tool(_symbolic_solve)
+symbolic_solve_tool["name"] = "symbolic_solve_tool"


### PR DESCRIPTION
## Summary
- Ensure tool dictionaries report public names like `calc_answer_tool` after wrapping with `function_tool`
- Update tests to look up new tool names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac14788b2883309ffaa480533410f6