### PR TITLE
Show QA agent messages in INFO logs

### DIFF
--- a/twin_generator/pipeline_helpers.py
+++ b/twin_generator/pipeline_helpers.py
@@ -10,6 +10,7 @@ from .tools.graph import render_graph_tool
 from .tools.html_table import make_html_table_tool
 from .tools.symbolic_solve import symbolic_solve_tool
 from .tools.qa_tools import (
+    _check_asset,
     check_asset_tool,
     sanitize_params_tool,
     validate_output_tool,
@@ -43,6 +44,7 @@ _QA_TOOLS = [
     sanitize_params_tool,
     validate_output_tool,
     check_asset_tool,
+    {"name": "_check_asset", "_func": _check_asset},
 ]
 _TEMPLATE_TOOLS = [calc_answer_tool]
 _TEMPLATE_MAX_RETRIES = 3

--- a/twin_generator/pipeline_runner.py
+++ b/twin_generator/pipeline_runner.py
@@ -81,18 +81,20 @@ class _Runner:
             return False, qa_out
         try:
             qa_res = AgentsRunner.run_sync(QAAgent, input=qa_in, tools=_QA_TOOLS)
-            qa_out = get_final_output(qa_res).strip().lower()
+            qa_raw = get_final_output(qa_res)
         except Exception as exc:  # pragma: no cover - defensive
             raise RuntimeError(f"QAAgent failed: {exc}")
+        qa_out = qa_raw.strip()
+        qa_lower = qa_out.lower()
         self.logger.info(
             "[twin-generator] step %d/%d: %s QA round %d: %s",
             idx + 1,
             total_steps,
             name,
             attempts + 1,
-            qa_out,
+            qa_out or "(empty response)",
         )
-        return qa_out == "pass", qa_out
+        return qa_lower == "pass", qa_out
 
     def run(self, inputs: PipelineState) -> PipelineState:
         data = copy.deepcopy(inputs)


### PR DESCRIPTION
## Summary
- log the raw QA agent response or indicate when it's empty
- expose `_check_asset` helper to QA tools for testing
- add regression test ensuring QA failure reasons appear in logs

## Testing
- `pre-commit run --files tests/test_pipeline.py twin_generator/pipeline_helpers.py twin_generator/pipeline_runner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac16cfc9508330aad5ba03b21d07bd