### PR TITLE
Propagate QA feedback to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Generate SAT-style "twin" math problems from a reference problem and official so
 - **FormatterAgent** – produce the final minified JSON payload.
 - **QAAgent** – validate JSON formatting and internal consistency.
 
+If QA detects a problem, the runner records the agent's message and feeds it
+back into the next attempt.  The feedback text is appended to subsequent
+prompts or included as a ``qa_feedback`` field in JSON payloads so agents can
+correct mistakes on retry.
+
 Optional agents such as **SymbolicSolveAgent** and **SymbolicSimplifyAgent** handle heavy symbolic manipulation when required.
 
 ## Installation

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,6 +2,11 @@
 
 Agents must read this document before calling any tool.
 
+If a QA check fails, the next agent run includes a ``qa_feedback`` field in its
+JSON payload (or appended text for plain prompts) containing the failure
+message. Agents should incorporate this feedback to fix the prior issues before
+responding again.
+
 ## calc_answer_tool
 Evaluates a mathematical expression with given parameters using SymPy. Use for exact numeric computation of expressions and intermediate results.
 

--- a/twin_generator/pipeline_runner.py
+++ b/twin_generator/pipeline_runner.py
@@ -86,6 +86,7 @@ class _Runner:
             raise RuntimeError(f"QAAgent failed: {exc}")
         qa_out = qa_raw.strip()
         qa_lower = qa_out.lower()
+        data.qa_feedback = qa_out
         self.logger.info(
             "[twin-generator] step %d/%d: %s QA round %d: %s",
             idx + 1,
@@ -118,6 +119,7 @@ class _Runner:
                 if skip_qa:
                     if next_steps:
                         steps[idx + 1 : idx + 1] = next_steps
+                    data.qa_feedback = None
                     break
                 from . import pipeline as pipeline_module
                 json_required = name in pipeline_module._JSON_STEPS
@@ -129,6 +131,7 @@ class _Runner:
                     data.error = str(exc)
                     return data
                 if passed:
+                    data.qa_feedback = None
                     if next_steps:
                         steps[idx + 1 : idx + 1] = next_steps
                     break
@@ -139,6 +142,8 @@ class _Runner:
                 ):
                     data.error = f"QA failed for {name}: {qa_out}"
                     return data
+                before.qa_feedback = data.qa_feedback
                 data = before
             idx += 1
+        data.qa_feedback = None
         return data

--- a/twin_generator/pipeline_state.py
+++ b/twin_generator/pipeline_state.py
@@ -41,6 +41,9 @@ class PipelineState:
     error: str | None = None
     extras: dict[str, Any] = field(default_factory=dict)
 
+    # QA feedback from failed checks
+    qa_feedback: str | None = None
+
     # Runner metadata
     skip_qa: bool = False
     next_steps: list[Callable[["PipelineState"], "PipelineState"]] | None = None

--- a/twin_generator/pipeline_steps.py
+++ b/twin_generator/pipeline_steps.py
@@ -34,7 +34,9 @@ def _step_parse(state: PipelineState) -> PipelineState:
         state.problem_text + "\n" + state.solution,
         tools=_TOOLS,
         max_retries=1,
+        qa_feedback=state.qa_feedback,
     )
+    state.qa_feedback = None
     if err:
         state.error = err
         return state
@@ -44,8 +46,13 @@ def _step_parse(state: PipelineState) -> PipelineState:
 
 def _step_concept(state: PipelineState) -> PipelineState:
     out, err = invoke_agent(
-        ConceptAgent, str(state.parsed), tools=_TOOLS, expect_json=False
+        ConceptAgent,
+        str(state.parsed),
+        tools=_TOOLS,
+        expect_json=False,
+        qa_feedback=state.qa_feedback,
     )
+    state.qa_feedback = None
     if err:
         state.error = err
         return state
@@ -60,7 +67,9 @@ def _step_template(state: PipelineState) -> PipelineState:
         payload,
         tools=_TEMPLATE_TOOLS,
         max_retries=_TEMPLATE_MAX_RETRIES,
+        qa_feedback=state.qa_feedback,
     )
+    state.qa_feedback = None
     if err:
         state.error = err
         return state
@@ -70,8 +79,12 @@ def _step_template(state: PipelineState) -> PipelineState:
 
 def _step_sample(state: PipelineState) -> PipelineState:
     out, err = invoke_agent(
-        SampleAgent, json.dumps({"template": state.template}), tools=_TOOLS
+        SampleAgent,
+        json.dumps({"template": state.template}),
+        tools=_TOOLS,
+        qa_feedback=state.qa_feedback,
     )
+    state.qa_feedback = None
     if err:
         state.error = err
         return state
@@ -85,8 +98,13 @@ def _step_sample(state: PipelineState) -> PipelineState:
 def _step_symbolic(state: PipelineState) -> PipelineState:
     payload = json.dumps({"template": state.template, "params": state.params})
     sol, err = invoke_agent(
-        SymbolicSolveAgent, payload, tools=_TOOLS, expect_json=False
+        SymbolicSolveAgent,
+        payload,
+        tools=_TOOLS,
+        expect_json=False,
+        qa_feedback=state.qa_feedback,
     )
+    state.qa_feedback = None
     if err:
         state.symbolic_error = err.replace("SymbolicSolveAgent", "Symbolic agents")
         return state
@@ -135,7 +153,10 @@ def _step_operations(state: PipelineState) -> PipelineState:
             data[field] = val
 
     payload = json.dumps({"data": data, "operations": ops})
-    out, err = invoke_agent(OperationsAgent, payload, tools=_TOOLS)
+    out, err = invoke_agent(
+        OperationsAgent, payload, tools=_TOOLS, qa_feedback=state.qa_feedback
+    )
+    state.qa_feedback = None
     if err:
         state.error = err
         return state
@@ -233,7 +254,13 @@ def _step_stem_choice(state: PipelineState) -> PipelineState:
     if state.table_html:
         payload["table_html"] = state.table_html
 
-    out, err = invoke_agent(StemChoiceAgent, json.dumps(payload), tools=_TOOLS)
+    out, err = invoke_agent(
+        StemChoiceAgent,
+        json.dumps(payload),
+        tools=_TOOLS,
+        qa_feedback=state.qa_feedback,
+    )
+    state.qa_feedback = None
     if err:
         state.error = err
         return state
@@ -255,7 +282,13 @@ def _step_format(state: PipelineState) -> PipelineState:
     if state.table_html:
         payload["table_html"] = state.table_html
 
-    out, err = invoke_agent(FormatterAgent, json.dumps(payload), tools=_TOOLS)
+    out, err = invoke_agent(
+        FormatterAgent,
+        json.dumps(payload),
+        tools=_TOOLS,
+        qa_feedback=state.qa_feedback,
+    )
+    state.qa_feedback = None
     if err:
         state.error = err
         return state


### PR DESCRIPTION
## Summary
- track QA failure messages via `qa_feedback` on `PipelineState`
- runner records QA feedback, retries with message, and clears on success
- agents receive feedback in prompts/payloads; docs explain new loop

## Testing
- `pre-commit run --files twin_generator/pipeline_state.py twin_generator/pipeline_runner.py twin_generator/pipeline_steps.py twin_generator/pipeline_helpers.py tests/test_pipeline.py README.md docs/tools.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac25dd5d5c83309b2f763978488343