### PR TITLE
Refactor invoke_agent retry loop

### DIFF
--- a/tests/test_pipeline_helpers.py
+++ b/tests/test_pipeline_helpers.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import pytest
+
+from twin_generator import pipeline_helpers
+
+
+def test_invoke_agent_stops_after_max_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def mock_run_sync(agent, input, tools=None):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(final_output="not json")
+
+    monkeypatch.setattr(pipeline_helpers.AgentsRunner, "run_sync", mock_run_sync)
+
+    out, err = pipeline_helpers.invoke_agent(SimpleNamespace(name="A"), "payload", max_retries=3)
+    assert out is None
+    assert err and err.startswith("A failed")
+    assert calls == 3
+
+
+def test_invoke_agent_success_returns_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def mock_run_sync(agent, input, tools=None):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(final_output='{"x": 1}')
+
+    monkeypatch.setattr(pipeline_helpers.AgentsRunner, "run_sync", mock_run_sync)
+
+    out, err = pipeline_helpers.invoke_agent(SimpleNamespace(name="A"), "payload", max_retries=5)
+    assert out == {"x": 1}
+    assert err is None
+    assert calls == 1
+
+
+def test_invoke_agent_stops_after_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    outputs = iter(["not json", '{"ok": true}', "should not reach"])
+    calls = 0
+
+    def mock_run_sync(agent, input, tools=None):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(final_output=next(outputs))
+
+    monkeypatch.setattr(pipeline_helpers.AgentsRunner, "run_sync", mock_run_sync)
+
+    out, err = pipeline_helpers.invoke_agent(SimpleNamespace(name="A"), "payload", max_retries=5)
+    assert out == {"ok": True}
+    assert err is None
+    assert calls == 2

--- a/twin_generator/pipeline_helpers.py
+++ b/twin_generator/pipeline_helpers.py
@@ -82,8 +82,8 @@ def invoke_agent(
     message if parsing ultimately fails.
     """
     agent_name = getattr(agent, "name", getattr(agent, "__name__", str(agent)))
-    attempts = 0
-    while True:
+    err_msg = "exceeded max retries"
+    for _attempt in range(max_retries):
         try:
             res = AgentsRunner.run_sync(agent, input=payload, tools=tools)
         except Exception as exc:  # pragma: no cover - defensive
@@ -97,6 +97,5 @@ def invoke_agent(
             parsed: Any = safe_json(out)
             return parsed, None
         except ValueError as exc:
-            attempts += 1
-            if attempts >= max_retries:
-                return None, f"{agent_name} failed: {exc}"
+            err_msg = str(exc)
+    return None, f"{agent_name} failed: {err_msg}"


### PR DESCRIPTION
## Summary
- use bounded `for` loop with max_retries in `invoke_agent`
- add tests validating retry behavior and early success

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac2651995483309fbc4327f0f242d8