### PR TITLE
Refactor visual step and add utility tests

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -378,6 +378,14 @@ def test_step_visual_accepts_point_formats(points: list[Any]) -> None:
     Path(out.graph_path).unlink(missing_ok=True)
 
 
+def test_step_visual_renders_table() -> None:
+    visual = {"type": "table", "data": {"header": ["A"], "rows": [[1], [2]]}}
+    state = PipelineState(template={"visual": visual})
+    out = pipeline._step_visual(state)
+    assert out.error is None
+    assert out.table_html and out.table_html.startswith("<table>")
+
+
 def test_step_sample_passes_through_params(monkeypatch: pytest.MonkeyPatch) -> None:
     def mock_run_sync(agent: Any, input: Any, tools: Any | None = None) -> SimpleNamespace:
         assert agent.name == "SampleAgent"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import importlib.util
+from pathlib import Path
+
+# Load utils module directly to avoid triggering package imports
+_utils_path = Path(__file__).resolve().parents[1] / "twin_generator" / "utils.py"
+_spec = importlib.util.spec_from_file_location("tg_utils", _utils_path)
+utils = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+assert _spec and _spec.loader
+_spec.loader.exec_module(utils)  # type: ignore[assignment]
+_normalize_graph_points = utils._normalize_graph_points
+
+
+def test_normalize_graph_points_converts_dicts() -> None:
+    spec = {"points": [{"X": 0, "Y": 1}, {"x": "2", "y": 3}, [4, 5]]}
+    _normalize_graph_points(spec)
+    assert spec["points"] == [[0.0, 1.0], [2.0, 3.0], [4, 5]]
+
+
+def test_normalize_graph_points_non_list_unchanged() -> None:
+    spec = {"points": "oops"}
+    _normalize_graph_points(spec)
+    assert spec["points"] == "oops"

--- a/twin_generator/pipeline_steps.py
+++ b/twin_generator/pipeline_steps.py
@@ -25,6 +25,7 @@ from .pipeline_helpers import (
 from .tools.calc import _calc_answer
 from .tools.graph import _render_graph
 from .tools.html_table import _make_html_table
+from .utils import _normalize_graph_points
 from .pipeline_state import PipelineState
 
 
@@ -168,42 +169,34 @@ def _step_operations(state: PipelineState) -> PipelineState:
     return state
 
 
+def _select_graph_spec(
+    visual: dict[str, Any], user_spec: Any, force: bool
+) -> Any:  # noqa: ANN401 - generic return
+    """Choose the graph spec given visual config, user override, and force flag."""
+    vtype = visual.get("type")
+    if force:
+        return user_spec or visual.get("data") or C.DEFAULT_GRAPH_SPEC
+    if vtype == "graph":
+        return visual.get("data") or user_spec or C.DEFAULT_GRAPH_SPEC
+    return None
+
+
+def _render_table(visual: dict[str, Any]) -> str | None:
+    """Render a table visual to HTML if applicable."""
+    if visual.get("type") == "table":
+        return _make_html_table(json.dumps(visual.get("data", {})))
+    return None
+
+
 def _step_visual(state: PipelineState) -> PipelineState:
     visual = state.template.get("visual") if isinstance(state.template, dict) else None
     if not isinstance(visual, dict):
         visual = {"type": "none"}
-    force = bool(state.force_graph)
-    user_spec = state.graph_spec
 
-    def _normalize_graph_points(spec: dict[str, Any]) -> None:
-        points = spec.get("points")
-        if not isinstance(points, list):
-            return
-        normalized: list[Any] = []
-        for pt in points:
-            if isinstance(pt, dict) and (
-                ("X" in pt and "Y" in pt) or ("x" in pt and "y" in pt)
-            ):
-                x = pt.get("X", pt.get("x"))
-                y = pt.get("Y", pt.get("y"))
-                if x is None or y is None:
-                    normalized.append(pt)
-                else:
-                    normalized.append([float(x), float(y)])
-            else:
-                normalized.append(pt)
-        spec["points"] = normalized
-
-    spec: Any = None
-    vtype = visual.get("type")
-    if force:
-        spec = user_spec or visual.get("data") or C.DEFAULT_GRAPH_SPEC
-    elif vtype == "graph":
-        spec = visual.get("data") or user_spec or C.DEFAULT_GRAPH_SPEC
-
+    spec = _select_graph_spec(visual, state.graph_spec, bool(state.force_graph))
     if spec is not None:
         if isinstance(spec, dict):
-            if force and not spec.get("points"):
+            if state.force_graph and not spec.get("points"):
                 spec["points"] = C.DEFAULT_GRAPH_SPEC.get("points", [])
             _normalize_graph_points(cast(dict[str, Any], spec))
         try:
@@ -212,8 +205,9 @@ def _step_visual(state: PipelineState) -> PipelineState:
             state.error = f"Invalid graph spec: {exc}"
         return state
 
-    if vtype == "table":
-        state.table_html = _make_html_table(json.dumps(visual.get("data", {})))
+    table_html = _render_table(visual)
+    if table_html is not None:
+        state.table_html = table_html
     return state
 
 

--- a/twin_generator/utils.py
+++ b/twin_generator/utils.py
@@ -182,3 +182,38 @@ def validate_output(block: dict[str, Any]) -> dict[str, Any]:
 
     block["errors"] = errors
     return block
+
+
+# ---------------------------------------------------------------------------
+# Graph helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_graph_points(spec: dict[str, Any]) -> None:
+    """In-place normalization of graph spec "points" values.
+
+    Accepts a specification dictionary that may contain a ``"points"`` key with
+    a list of coordinate pairs. Coordinates expressed as dictionaries with
+    ``X``/``Y`` or ``x``/``y`` keys are coerced to ``[x, y]`` lists with ``float``
+    values. Any non-conforming entries are left untouched.
+    """
+
+    points = spec.get("points")
+    if not isinstance(points, list):
+        return
+
+    normalized: list[Any] = []
+    for pt in points:
+        if isinstance(pt, dict) and (
+            ("X" in pt and "Y" in pt) or ("x" in pt and "y" in pt)
+        ):
+            x = pt.get("X", pt.get("x"))
+            y = pt.get("Y", pt.get("y"))
+            if x is None or y is None:
+                normalized.append(pt)
+            else:
+                normalized.append([float(x), float(y)])
+        else:
+            normalized.append(pt)
+
+    spec["points"] = normalized


### PR DESCRIPTION
## Summary
- extract `_normalize_graph_points` into reusable helper
- refactor `_step_visual` into smaller helpers for graphs and tables
- add tests for graph point normalization and table rendering

## Testing
- `pre-commit run --files twin_generator/utils.py twin_generator/pipeline_steps.py tests/test_pipeline.py tests/test_utils.py`
- `pytest tests/test_utils.py -q`
- `pytest tests/test_pipeline.py::test_step_visual_renders_table tests/test_pipeline.py::test_step_visual_accepts_point_formats -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac269a970c8330b256dde0b3c48281