### PR TITLE
Retry QA step on agent exceptions

### DIFF
--- a/tests/test_runner_qa_exception.py
+++ b/tests/test_runner_qa_exception.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import twin_generator.pipeline as pipeline  # noqa: E402
+
+
+def _qa_response(out: str, tools: Any | None) -> SimpleNamespace:
+    tool_map = {t["name"]: t for t in (tools or [])}
+    func = tool_map.get("sanitize_params_tool", {}).get("_func")
+    if func:
+        func("{}")
+    return SimpleNamespace(final_output=out)
+
+
+@pytest.mark.parametrize("always_fail", [False, True])
+def test_runner_retries_on_qa_exception(
+    monkeypatch: pytest.MonkeyPatch, always_fail: bool
+) -> None:
+    """_Runner should retry steps when QA agent raises an exception."""
+
+    call_counts: dict[str, int] = {}
+
+    def mock_run_sync(agent: Any, input: Any, tools: Any | None = None) -> SimpleNamespace:
+        name = agent.name
+        call_counts[name] = call_counts.get(name, 0) + 1
+        if name == "ParserAgent":
+            return SimpleNamespace(final_output=1)
+        if name == "QAAgent":
+            if always_fail or call_counts[name] == 1:
+                raise RuntimeError("boom")
+            return _qa_response("pass", tools)
+        raise AssertionError(f"unexpected agent {name}")
+
+    monkeypatch.setattr(pipeline.AgentsRunner, "run_sync", mock_run_sync)
+
+    def _step_good(state: pipeline.PipelineState) -> pipeline.PipelineState:
+        res = pipeline.AgentsRunner.run_sync(pipeline.ParserAgent, input="x")
+        state.extras["out"] = res.final_output
+        return state
+
+    runner = pipeline._Runner(pipeline._Graph([_step_good]), qa_max_retries=2)
+    out = runner.run(pipeline.PipelineState())
+
+    if always_fail:
+        assert out.error == "QA failed for good: boom"
+        assert call_counts.get("ParserAgent") == 2
+        assert call_counts.get("QAAgent") == 2
+    else:
+        assert out.error is None
+        assert out.extras["out"] == 1
+        assert call_counts.get("ParserAgent") == 2
+        assert call_counts.get("QAAgent") == 2
+

--- a/twin_generator/pipeline_runner.py
+++ b/twin_generator/pipeline_runner.py
@@ -83,7 +83,17 @@ class _Runner:
             qa_res = AgentsRunner.run_sync(QAAgent, input=qa_in, tools=_QA_TOOLS)
             qa_raw = get_final_output(qa_res)
         except Exception as exc:  # pragma: no cover - defensive
-            raise RuntimeError(f"QAAgent failed: {exc}")
+            qa_out = str(exc)
+            data.qa_feedback = qa_out
+            self.logger.info(
+                "[twin-generator] step %d/%d: %s QA round %d: %s",
+                idx + 1,
+                total_steps,
+                name,
+                attempts + 1,
+                qa_out,
+            )
+            return False, qa_out
         qa_out = qa_raw.strip()
         qa_lower = qa_out.lower()
         data.qa_feedback = qa_out


### PR DESCRIPTION
## Summary
- handle QA agent errors by returning failure instead of raising
- ensure QA retries respect `qa_max_retries`
- test runner retry logic when QA agent raises

## Testing
- `pytest -q`
- `mypy twin_generator/pipeline_runner.py tests/test_runner_qa_exception.py`
- `pre-commit run --files twin_generator/pipeline_runner.py tests/test_runner_qa_exception.py`


------
https://chatgpt.com/codex/tasks/task_e_68afba2a0c108330803ccfb23d058b30