### PR TITLE
Fix QA tool specs and add validation test

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -802,7 +802,7 @@ def test_qa_accepts_missing_assets(monkeypatch: pytest.MonkeyPatch) -> None:
             payload = json.loads(input)
             data = payload["data"]
             tool_map = {t["name"]: t for t in (tools or [])}
-            ok = tool_map["_check_asset"]["_func"](
+            ok = tool_map["check_asset_tool"]["_func"](
                 data.get("graph_path"), data.get("table_html")
             )
             return SimpleNamespace(final_output="pass" if ok else "missing asset")

--- a/tests/test_qa_tools.py
+++ b/tests/test_qa_tools.py
@@ -9,6 +9,30 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from twin_generator.tools.qa_tools import _check_asset  # noqa: E402
 
 
+def test_qa_tools_validate_and_run(monkeypatch):
+    import types
+    from twin_generator.pipeline_helpers import AgentsRunner, _QA_TOOLS  # noqa: E402
+    from twin_generator.agents import QAAgent  # noqa: E402
+
+    sanitized: list[dict[str, object]] = []
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.responses = self
+
+        def create(self, **kwargs):
+            sanitized.extend(kwargs.get("tools", []))
+            return types.SimpleNamespace(status="completed", output_text="pass")
+
+    fake_openai = types.SimpleNamespace(OpenAI=lambda: DummyClient())
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+    res = AgentsRunner.run_sync(QAAgent, input="{}", tools=_QA_TOOLS)
+
+    assert res.final_output == "pass"
+    assert sanitized and all("type" in t for t in sanitized)
+
+
 def test_check_asset_true_when_no_assets() -> None:
     assert _check_asset() is True
     assert _check_asset("", "") is True

--- a/twin_generator/pipeline_helpers.py
+++ b/twin_generator/pipeline_helpers.py
@@ -11,7 +11,6 @@ from .tools.graph import render_graph_tool
 from .tools.html_table import make_html_table_tool
 from .tools.symbolic_solve import symbolic_solve_tool
 from .tools.qa_tools import (
-    _check_asset,
     check_asset_tool,
     sanitize_params_tool,
     validate_output_tool,
@@ -45,7 +44,6 @@ _QA_TOOLS = [
     sanitize_params_tool,
     validate_output_tool,
     check_asset_tool,
-    {"name": "_check_asset", "_func": _check_asset},
 ]
 _TEMPLATE_TOOLS = [calc_answer_tool]
 _TEMPLATE_MAX_RETRIES = 3


### PR DESCRIPTION
## Summary
- remove raw `_check_asset` mapping from `_QA_TOOLS` so every tool has a valid spec
- adjust QA pipeline test to use `check_asset_tool`
- add regression test verifying `_QA_TOOLS` validate and QAAgent runs without OpenAI errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afba3c4c4483308df9f24d79c365dc