### PR TITLE
Add OpenAI dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Optional agents such as **SymbolicSolveAgent** and **SymbolicSimplifyAgent** han
 
 ## Installation
 
-This project requires **Python 3.12+**. Install in editable mode with development dependencies:
+This project requires **Python 3.12+** and the official `openai` package. Install in editable mode with development dependencies:
 
 ```bash
 pip install -e .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ mypy
 pre-commit
 sympy
 json5
+openai

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "pillow",
         "numpy",
         "python-dotenv",
+        "openai",
         "openai-agents",
     ],
     entry_points={


### PR DESCRIPTION
## Summary
- include `openai` in project install and dev requirements
- document `openai` as a required package in installation instructions

## Testing
- `pre-commit run --files setup.py requirements-dev.txt README.md`
- `pytest` *(fails: FunctionTool object does not support item assignment)*
- `mypy --config-file=mypy.ini twin_generator`


------
https://chatgpt.com/codex/tasks/task_e_68afba5f7fd8833085cebb3e7a1fa8f6