### PR TITLE
Allow optional graph title in GraphSpec

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -402,6 +402,15 @@ def test_step_visual_accepts_point_formats(points: list[Any]) -> None:
     Path(out.graph_path).unlink(missing_ok=True)
 
 
+def test_step_visual_handles_spec_without_title() -> None:
+    spec: GraphSpec = {"points": [[0, 0], [1, 1]], "style": "line"}
+    state = PipelineState(template={"visual": {"type": "graph", "data": spec}})
+    out = pipeline._step_visual(state)
+    assert out.error is None
+    assert out.graph_path and Path(out.graph_path).is_file()
+    Path(out.graph_path).unlink(missing_ok=True)
+
+
 def test_step_visual_renders_table() -> None:
     visual = {"type": "table", "data": {"header": ["A"], "rows": [[1], [2]]}}
     state = PipelineState(template={"visual": visual})

--- a/twin_generator/constants.py
+++ b/twin_generator/constants.py
@@ -1,6 +1,6 @@
 """Package‑wide constants and demo assets."""
 
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 class GraphSpec(TypedDict):
@@ -8,7 +8,7 @@ class GraphSpec(TypedDict):
 
     points: list[list[float]]
     style: str
-    title: str
+    title: NotRequired[str]
 
 
 _DEMO_PROBLEM = """If 3x + 2 = 17, what is the value of x?"""


### PR DESCRIPTION
## Summary
- allow GraphSpec title to be optional
- test pipeline visual step with graph spec lacking title

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afba6e6b988330ae5f6352322b952b