### PR TITLE
feat: estimate degrees of freedom

### DIFF
--- a/micro_solver/state.py
+++ b/micro_solver/state.py
@@ -51,6 +51,7 @@ class MicroState:
     # Meta‑reasoning stats
     eq_count: int = 0
     ineq_count: int = 0
+    jacobian_rank: int = 0
     degrees_of_freedom: int = 0
     needs_replan: bool = False
 

--- a/micro_solver/steps_candidate.py
+++ b/micro_solver/steps_candidate.py
@@ -192,6 +192,10 @@ def _micro_verify_sympy(state: MicroState) -> MicroState:
 
 
 def _micro_solve_sympy(state: MicroState) -> MicroState:
+    # Only attempt solving when the system appears determined
+    if state.eq_count == 0 or state.degrees_of_freedom != 0:
+        state.skip_qa = True
+        return state
     target = _infer_target_var(state)
     sols: list[str] = []
     if target:


### PR DESCRIPTION
## Summary
- track Jacobian rank and DOF in `MicroState`
- add `estimate_jacobian_rank` helper and improved DOF monitoring
- skip symbolic solve when system under- or over-determined

## Testing
- `pre-commit run --files micro_solver/state.py micro_solver/steps_candidate.py micro_solver/steps_meta.py micro_solver/sym_utils.py` *(fails: "Agent has no attribute reasoning_effort" and other mypy errors in unrelated files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5644304f08330a80b4f082fbfe06d