### PR TITLE
Fix scheduler replan flag override

### DIFF
--- a/micro_solver/steps_meta.py
+++ b/micro_solver/steps_meta.py
@@ -31,5 +31,6 @@ def _micro_monitor_dof(state: MicroState) -> MicroState:
     state.ineq_count = ineq_count
     state.jacobian_rank = rank
     state.degrees_of_freedom = len(unknowns) - rank
-    state.needs_replan = state.degrees_of_freedom != 0
+    # ``needs_replan`` is controlled externally and should not be
+    # overwritten simply because degrees of freedom remain non-zero.
     return state

--- a/tests/test_scheduler_replan_flag.py
+++ b/tests/test_scheduler_replan_flag.py
@@ -1,0 +1,23 @@
+from typing import Tuple
+
+from micro_solver.scheduler import solve
+from micro_solver.state import MicroState
+from micro_solver.operators import Operator
+
+
+class DummyOperator(Operator):
+    name = "dummy"
+
+    def applicable(self, state: MicroState) -> bool:
+        return True
+
+    def apply(self, state: MicroState) -> Tuple[MicroState, float]:
+        state.final_answer = 42
+        return state, 1.0
+
+
+def test_scheduler_applies_operator_without_spurious_replan() -> None:
+    state = MicroState()
+    state.variables = ["x"]  # ensures non-zero degrees of freedom
+    result = solve(state, [DummyOperator()], max_iters=2)
+    assert result.final_answer == 42


### PR DESCRIPTION
## Summary
- Stop `_micro_monitor_dof` from forcing `needs_replan` based on degrees of freedom
- Add regression test to ensure scheduler applies operators when replan flag isn't set

## Testing
- `pre-commit run --files micro_solver/steps_meta.py tests/test_scheduler_replan_flag.py` *(fails: Agent.reasoning_effort attributes and other unrelated mypy errors)*
- `flake8 micro_solver/steps_meta.py tests/test_scheduler_replan_flag.py`
- `mypy --config-file=mypy.ini --follow-imports=skip micro_solver/steps_meta.py tests/test_scheduler_replan_flag.py`
- `pytest` *(fails: missing sympy/matplotlib and other dependencies)*
- `PYTHONPATH=. pytest tests/test_scheduler_replan_flag.py`


------
https://chatgpt.com/codex/tasks/task_e_68b56d8d743c833088be39e3d96a88aa