### PR TITLE
feat: add DOF-gated solver operator

### DIFF
--- a/micro_solver/__init__.py
+++ b/micro_solver/__init__.py
@@ -21,6 +21,7 @@ from .operators import (
     SimplifyOperator,
     SubstituteOperator,
     FeasibleSampleOperator,
+    SolveOperator,
     VerifyOperator,
 )  # noqa: F401
 from .scheduler import solve  # noqa: F401
@@ -36,6 +37,7 @@ __all__ = [
     "SimplifyOperator",
     "SubstituteOperator",
     "FeasibleSampleOperator",
+    "SolveOperator",
     "VerifyOperator",
     "solve",
 ]

--- a/tests/test_solve_operator.py
+++ b/tests/test_solve_operator.py
@@ -1,0 +1,20 @@
+from micro_solver.scheduler import solve
+from micro_solver.state import MicroState
+from micro_solver.operators import SolveOperator, VerifyOperator
+
+
+def test_solve_operator_gated_by_dof() -> None:
+    state = MicroState()
+    state.variables = ["x"]
+    state.relations = ["x + 2 = 5"]
+    result = solve(state, [SolveOperator(), VerifyOperator()], max_iters=4)
+    assert result.final_answer == "3"
+
+
+def test_solve_operator_skipped_when_underdetermined() -> None:
+    state = MicroState()
+    state.variables = ["x", "y"]
+    state.relations = ["x + y = 5"]
+    result = solve(state, [SolveOperator(), VerifyOperator()], max_iters=2)
+    assert result.final_answer is None
+    assert result.candidate_answers == []


### PR DESCRIPTION
## Summary
- add SolveOperator that produces candidates only when the system is determined
- gate VerifyOperator on degrees of freedom
- expose SolveOperator in micro_solver package
- test SolveOperator and DOF gating behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b57029b450833086ea30cfda7fbe61