### PR TITLE
Handle env bindings in solve operator

### DIFF
--- a/tests/test_solve_operator.py
+++ b/tests/test_solve_operator.py
@@ -18,3 +18,13 @@ def test_solve_operator_skipped_when_underdetermined() -> None:
     result = solve(state, [SolveOperator(), VerifyOperator()], max_iters=2)
     assert result.final_answer is None
     assert result.candidate_answers == []
+
+
+def test_solve_operator_respects_env_bindings() -> None:
+    state = MicroState()
+    state.variables = ["x", "y"]
+    state.env = {"x": 1}
+    state.relations = ["x + y = 3"]
+    result = solve(state, [SolveOperator(), VerifyOperator()], max_iters=4)
+    assert result.candidate_answers == ["2"]
+    assert result.final_answer == "2"


### PR DESCRIPTION
## Summary
- substitute bound variables into relations when solving or verifying
- choose first unbound symbol as solve target and during verification
- test solving when earlier variables are already bound

## Testing
- `pre-commit run --files micro_solver/operators.py tests/test_solve_operator.py` *(fails: mypy errors in unrelated files)*
- `PYTHONPATH=. pytest tests/test_solve_operator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6378c112083309ebba4b4913b7833