### PR TITLE
feat: add default operator scheduler entrypoint

### DIFF
--- a/micro_solver/__init__.py
+++ b/micro_solver/__init__.py
@@ -23,8 +23,9 @@ from .operators import (
     FeasibleSampleOperator,
     SolveOperator,
     VerifyOperator,
+    DEFAULT_OPERATORS,
 )  # noqa: F401
-from .scheduler import solve  # noqa: F401
+from .scheduler import solve, solve_with_defaults  # noqa: F401
 
 __all__ = [
     "MicroState",
@@ -39,6 +40,8 @@ __all__ = [
     "FeasibleSampleOperator",
     "SolveOperator",
     "VerifyOperator",
+    "DEFAULT_OPERATORS",
     "solve",
+    "solve_with_defaults",
 ]
 

--- a/micro_solver/operators.py
+++ b/micro_solver/operators.py
@@ -131,3 +131,16 @@ class VerifyOperator(Operator):
             state.final_answer = candidate
             return state, 1.0
         return state, 0.0
+
+
+# Default operator pool used by the high-level scheduler entrypoint.
+#
+# The set is intentionally small; it demonstrates the operator protocol with a
+# mix of symbolic and validation steps while keeping the scheduling loop
+# lightweight.  Additional operators can be appended by callers as needed.
+DEFAULT_OPERATORS: list[Operator] = [
+    SolveOperator(),
+    VerifyOperator(),
+    SimplifyOperator(),
+]
+

--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Sequence
 
 from .state import MicroState
-from .operators import Operator
+from .operators import Operator, DEFAULT_OPERATORS
 from .steps_meta import _micro_monitor_dof
 from .certificate import build_certificate
 
@@ -68,3 +68,10 @@ def solve(state: MicroState, operators: Sequence[Operator], *, max_iters: int = 
     except Exception:
         pass
     return state
+
+
+def solve_with_defaults(state: MicroState, *, max_iters: int = 10) -> MicroState:
+    """Solve ``state`` using the built-in default operator pool."""
+
+    return solve(state, DEFAULT_OPERATORS, max_iters=max_iters)
+

--- a/tests/test_scheduler_defaults.py
+++ b/tests/test_scheduler_defaults.py
@@ -1,0 +1,10 @@
+from micro_solver.scheduler import solve_with_defaults
+from micro_solver.state import MicroState
+
+
+def test_default_operator_pool_solves_linear_equation() -> None:
+    state = MicroState()
+    state.variables = ["x"]
+    state.relations = ["x + 2 = 5"]
+    result = solve_with_defaults(state, max_iters=4)
+    assert result.final_answer == "3"


### PR DESCRIPTION
## Summary
- provide a default operator pool for the micro-solver
- expose `solve_with_defaults` helper to run the progress-driven scheduler
- test solving a linear equation with the default operators

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b63796a75883308770527f6f428a19