### PR TITLE
Handle fully bound states in SolveOperator

### DIFF
--- a/tests/test_solve_operator.py
+++ b/tests/test_solve_operator.py
@@ -28,3 +28,13 @@ def test_solve_operator_respects_env_bindings() -> None:
     result = solve(state, [SolveOperator(), VerifyOperator()], max_iters=4)
     assert result.candidate_answers == ["2"]
     assert result.final_answer == "2"
+
+
+def test_solve_operator_surfaces_bound_values() -> None:
+    state = MicroState()
+    state.variables = ["x"]
+    state.env = {"x": 2}
+    state.relations = ["x = 2"]
+    result = solve(state, [SolveOperator(), VerifyOperator()], max_iters=4)
+    assert result.candidate_answers == ["2"]
+    assert result.final_answer == "2"


### PR DESCRIPTION
## Summary
- ensure SolveOperator still produces candidate answers when all variables are bound
- fallback to first variable and emit its value from env
- add regression test for bound state solving

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b63bed990c8330a5118f1de5925adc