### PR TITLE
test: cover scheduler certificate

### DIFF
--- a/tests/test_scheduler_certificate.py
+++ b/tests/test_scheduler_certificate.py
@@ -1,0 +1,16 @@
+from micro_solver.scheduler import solve_with_defaults
+from micro_solver.state import MicroState
+import pytest
+
+
+def test_certificate_records_best_candidate() -> None:
+    state = MicroState()
+    state.variables = ["x"]
+    state.relations = ["x + 2 = 5"]
+    result = solve_with_defaults(state, max_iters=4)
+    cert = result.certificate
+    assert cert is not None
+    assert cert.verified is True
+    assert str(cert.value) == "3"
+    # Residual for solved relation should be close to zero
+    assert cert.residuals.get("x + 2 = 5", 1.0) == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add regression test for scheduler certificate to ensure verified candidate and residuals are recorded

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b63c153b2083308c204cb40bf573f8