### PR TITLE
Switch micro-solver to progress scheduler

### DIFF
--- a/micro_solver/README.md
+++ b/micro_solver/README.md
@@ -6,7 +6,7 @@ What It Is
 The micro‑solver is an additive, ultra‑granular multi‑agent pipeline that solves math problems by decomposing them into very small, verifiable steps aligned with a cognitive model:
 
 - Recognition: encode the problem into a structured internal representation.
-- Reasoning: choose a schema/strategy and produce an atomic action plan.
+- Reasoning: retrieve schemas/strategies and let a progress-based scheduler apply operators.
 - Calculation: execute one atomic action at a time, verify, and finish.
 
 It emphasizes strict I/O contracts, deterministic post‑conditions, and per‑step QA. The goal is to minimize per‑agent cognitive load and reduce compounding errors.
@@ -25,8 +25,8 @@ High‑Level Pipeline
 Default graph (simplified names):
 
 1) normalize → 2) tokenize → 3) entities → 4) relations → 5) goal → 6) classify → 7) repr →
-8) schema → 9) strategies → 10) choose_strategy → 11) decompose → 12) execute_plan →
-13) solve_sympy → 14) extract_candidate → 15) simplify_candidate_sympy → 16) verify_sympy
+8) schema → 9) strategies → 10) execute_plan (scheduler) →
+11) solve_sympy → 12) extract_candidate → 13) simplify_candidate_sympy → 14) verify_sympy
 
 - Early exit: the runner exits as soon as `final_answer` is set and QA passes.
 - Retries: each step retries with QA feedback up to a small budget.
@@ -44,9 +44,7 @@ Recognition
 Reasoning
 - `SchemaRetrieverAgent`: schemas[] (named canonical patterns)
 - `StrategyEnumeratorAgent`: strategies[] (micro‑plan names)
-- `PreconditionCheckerAgent`: ok/reasons per strategy
-- `StepDecomposerAgent`: plan_steps[{id, action, args}] (planning‑only; no computed results)
-- `NextActionAgent`: next_step (one atomic action at a time)
+- `scheduler.solve_with_defaults`: progress‑based operator loop
 
 Calculation
 - `RewriteAgent`: applies one atomic algebraic action and returns new_relations

--- a/micro_solver/agents/qa.py
+++ b/micro_solver/agents/qa.py
@@ -16,7 +16,6 @@ MicroQAAgent = Agent(
         "- relations: require a non‑empty array of strings (algebraic relations). "
         "- extract_candidate: candidate may be numeric or an expression; do not require justification here (verification handles it). "
         "Additional guards for counting tasks (goal mentions 'count' or 'number of'): "
-        "- choose_strategy: reject parity/GF(2) strategies when text says 'exactly k' since they drop cardinality. "
         "- verify: require the final to be a non‑negative integer supported by relations naming the count; reject trivial 0 with no justification."
     ),
     model="gpt-5-nano",

--- a/micro_solver/steps.py
+++ b/micro_solver/steps.py
@@ -17,7 +17,6 @@ from .steps_recognition import (
 from .steps_reasoning import (
     _micro_schema,
     _micro_strategies,
-    _micro_choose_strategy,
 )
 from .steps_execution import _micro_execute_plan
 from .steps_candidate import (
@@ -41,7 +40,6 @@ DEFAULT_MICRO_STEPS = [
     _micro_repr,
     _micro_schema,
     _micro_strategies,
-    _micro_choose_strategy,
     _micro_execute_plan,
     _micro_monitor_dof,
 ]
@@ -65,7 +63,6 @@ def build_steps(*, max_iters: Optional[int] = None) -> list:
         _micro_repr,
         _micro_schema,
         _micro_strategies,
-        _micro_choose_strategy,
         _exec,
         _micro_monitor_dof,
         _micro_solve_sympy,


### PR DESCRIPTION
## Summary
- drop `_micro_choose_strategy` from default step pipeline
- run plan execution through `scheduler.solve_with_defaults`
- document scheduler-based execution and remove legacy strategy references

## Testing
- `pre-commit run --files docs/micro_solver.md micro_solver/README.md micro_solver/agents/qa.py micro_solver/orchestrator.py micro_solver/steps.py` *(fails: "Agent" has no attribute "reasoning_effort" and other mypy errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b644c17efc8330819b5d3cdad9e8a7