### PR TITLE
Refactor MicroState into R/C/V/A/M structure

### DIFF
--- a/micro_solver/operators.py
+++ b/micro_solver/operators.py
@@ -73,12 +73,12 @@ class SimplifyOperator(Operator):
     name: str = "simplify"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return bool(state.relations)
+        return bool(state.C["symbolic"])
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
-        before = sum(len(r) for r in state.relations)
-        state.relations = [simplify_expr(r) for r in state.relations]
-        after = sum(len(r) for r in state.relations)
+        before = sum(len(r) for r in state.C["symbolic"])
+        state.C["symbolic"] = [simplify_expr(r) for r in state.C["symbolic"]]
+        after = sum(len(r) for r in state.C["symbolic"])
         delta = float(before - after)
         return state, delta
 
@@ -91,13 +91,13 @@ class SubstituteOperator(Operator):
     name: str = "substitute"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return bool(self.replacements) and bool(state.relations)
+        return bool(self.replacements) and bool(state.C["symbolic"])
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         step = {"action": "substitute", "args": {"replacements": self.replacements}}
-        new_rel = rewrite_relations(state.relations, step)
-        delta = float(len(state.relations) - len(new_rel))
-        state.relations = new_rel
+        new_rel = rewrite_relations(state.C["symbolic"], step)
+        delta = float(len(state.C["symbolic"]) - len(new_rel))
+        state.C["symbolic"] = new_rel
         return state, delta
 
 
@@ -108,13 +108,13 @@ class FeasibleSampleOperator(Operator):
     name: str = "feasible_sample"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return bool(state.variables)
+        return bool(state.V["symbolic"]["variables"])
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         import random
 
-        sample = {v: random.random() for v in state.variables}
-        state.derived["sample"] = sample
+        sample = {v: random.random() for v in state.V["symbolic"]["variables"]}
+        state.V["symbolic"]["derived"]["sample"] = sample
         return state, 0.0
 
 
@@ -127,30 +127,30 @@ class SolveOperator(Operator):
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
         return (
             state.degrees_of_freedom == 0
-            and bool(state.relations)
-            and not state.candidate_answers
+            and bool(state.C["symbolic"])
+            and not state.A["symbolic"]["candidates"]
         )
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         # Pick the first variable that is not yet bound in the environment.
         # When all variables are bound already, fall back to the first variable
         # so that its value can still be surfaced as a candidate answer.
-        target = next((v for v in state.variables if v not in state.env), None)
-        if target is None and state.variables:
-            target = state.variables[0]
+        target = next((v for v in state.V["symbolic"]["variables"] if v not in state.V["symbolic"]["env"]), None)
+        if target is None and state.V["symbolic"]["variables"]:
+            target = state.V["symbolic"]["variables"][0]
 
         # Substitute known bindings into the relations before solving
-        rels = _apply_env(state.relations, state.env)
+        rels = _apply_env(state.C["symbolic"], state.V["symbolic"]["env"])
 
         sols: list[Any]
-        if target in state.env:
-            sols = [str(state.env[target])]
+        if target in state.V["symbolic"]["env"]:
+            sols = [str(state.V["symbolic"]["env"][target])]
         else:
             sols = solve_for(rels, target) if target else []
             if not sols:
                 sols = solve_any(rels)
         if sols:
-            state.candidate_answers.extend(sols)
+            state.A["symbolic"]["candidates"].extend(sols)
             return state, 1.0
         return state, 0.0
 
@@ -164,24 +164,24 @@ class VerifyOperator(Operator):
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
         return (
             state.degrees_of_freedom == 0
-            and bool(state.candidate_answers)
-            and state.final_answer is None
+            and bool(state.A["symbolic"]["candidates"])
+            and state.A["symbolic"]["final"] is None
         )
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         try:
-            candidate = str(state.candidate_answers[-1])
+            candidate = str(state.A["symbolic"]["candidates"][-1])
         except Exception:
             return state, 0.0
 
         # Choose the variable corresponding to the candidate: first unbound symbol
-        var = next((v for v in state.variables if v not in state.env), None)
+        var = next((v for v in state.V["symbolic"]["variables"] if v not in state.V["symbolic"]["env"]), None)
 
         # Substitute known bindings into the relations before verification
-        rels = _apply_env(state.relations, state.env)
+        rels = _apply_env(state.C["symbolic"], state.V["symbolic"]["env"])
 
         if verify_candidate(rels, candidate, varname=var):
-            state.final_answer = candidate
+            state.A["symbolic"]["final"] = candidate
             return state, 1.0
         return state, 0.0
 
@@ -196,20 +196,20 @@ class EliminateOperator(Operator):
     name: str = "eliminate"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return len(state.variables) > 1 and bool(state.relations)
+        return len(state.V["symbolic"]["variables"]) > 1 and bool(state.C["symbolic"])
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
-        target = state.variables[-1]
-        before = sum(r.count(target) for r in state.relations)
+        target = state.V["symbolic"]["variables"][-1]
+        before = sum(r.count(target) for r in state.C["symbolic"])
         new_rel = rewrite_relations(
-            state.relations,
+            state.C["symbolic"],
             {"action": "eliminate_symbol", "args": {"symbol": target}},
         )
         after = sum(r.count(target) for r in new_rel)
         delta = float(before - after)
         if delta > 0:
-            state.relations = new_rel
-            state.variables = [v for v in state.variables if v != target]
+            state.C["symbolic"] = new_rel
+            state.V["symbolic"]["variables"] = [v for v in state.V["symbolic"]["variables"] if v != target]
         return state, delta
 
 
@@ -224,13 +224,13 @@ class TransformOperator(Operator):
     name: str = "transform"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return bool(state.relations)
+        return bool(state.C["symbolic"])
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
-        before = sum(len(r) for r in state.relations)
-        new_rel = rewrite_relations(state.relations, {"action": self.action})
+        before = sum(len(r) for r in state.C["symbolic"])
+        new_rel = rewrite_relations(state.C["symbolic"], {"action": self.action})
         after = sum(len(r) for r in new_rel)
-        state.relations = new_rel
+        state.C["symbolic"] = new_rel
         return state, float(before - after)
 
 
@@ -243,7 +243,7 @@ class CaseSplitOperator(Operator):
     name: str = "case_split"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return bool(state.relations)
+        return bool(state.C["symbolic"])
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         try:
@@ -255,7 +255,7 @@ class CaseSplitOperator(Operator):
             )
             trans = (*standard_transformations, implicit_multiplication_application)
             cases: list[str] = []
-            for r in state.relations:
+            for r in state.C["symbolic"]:
                 op, lhs, rhs = parse_relation_sides(r)
                 if op != "=":
                     continue
@@ -268,7 +268,7 @@ class CaseSplitOperator(Operator):
                     cases.append(f"{sp.sstr(sym)} = {sp.sstr(-root)}")
                     break
             if cases:
-                state.derived["cases"] = cases
+                state.V["symbolic"]["derived"]["cases"] = cases
                 return state, float(len(cases))
         except Exception:
             pass
@@ -284,14 +284,14 @@ class BoundInferOperator(Operator):
     name: str = "bound_infer"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return bool(state.relations)
+        return bool(state.C["symbolic"])
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         try:
             import sympy as sp
-            bounds = dict(state.derived.get("bounds", {}))
+            bounds = dict(state.V["symbolic"]["derived"].get("bounds", {}))
             changes = 0
-            for r in state.relations:
+            for r in state.C["symbolic"]:
                 op, lhs, rhs = parse_relation_sides(r)
                 if op not in ("<", "<=", ">", ">="):
                     continue
@@ -312,7 +312,7 @@ class BoundInferOperator(Operator):
                         changes += 1
                 bounds[key] = (low, high)
             if changes:
-                state.derived["bounds"] = bounds
+                state.V["symbolic"]["derived"]["bounds"] = bounds
             return state, float(changes)
         except Exception:
             return state, 0.0
@@ -327,18 +327,18 @@ class NumericSolveOperator(Operator):
     name: str = "numeric_solve"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return bool(state.relations) and not state.candidate_answers
+        return bool(state.C["symbolic"]) and not state.A["symbolic"]["candidates"]
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
-        for r in state.relations:
+        for r in state.C["symbolic"]:
             op, lhs, rhs = parse_relation_sides(r)
             if op != "=":
                 continue
-            ok, val = evaluate_with_env(rhs, state.env)
+            ok, val = evaluate_with_env(rhs, state.V["symbolic"]["env"])
             if not ok:
                 ok, val = evaluate_numeric(rhs)
             if ok:
-                state.candidate_answers.append(str(val))
+                state.A["symbolic"]["candidates"].append(str(val))
                 return state, 1.0
         return state, 0.0
 
@@ -352,11 +352,11 @@ class GridRefineOperator(Operator):
     name: str = "grid_refine"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        sample = state.derived.get("sample")
+        sample = state.V["symbolic"]["derived"].get("sample")
         return isinstance(sample, dict) and bool(sample)
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
-        sample = dict(state.derived.get("sample", {}))
+        sample = dict(state.V["symbolic"]["derived"].get("sample", {}))
         changes = 0
         for k, v in sample.items():
             try:
@@ -367,7 +367,7 @@ class GridRefineOperator(Operator):
             except Exception:
                 continue
         if changes:
-            state.derived["sample"] = sample
+            state.V["symbolic"]["derived"]["sample"] = sample
         return state, float(changes)
 
 
@@ -375,23 +375,23 @@ class GridRefineOperator(Operator):
 class QuadratureOperator(Operator):
     """Compute a definite integral stored in ``derived``.
 
-    Expects ``state.derived['integrand']`` (expression in ``x``) and
-    ``state.derived['interval']`` as ``(a, b)``.
+    Expects ``state.V["symbolic"]["derived"]['integrand']`` (expression in ``x``) and
+    ``state.V["symbolic"]["derived"]['interval']`` as ``(a, b)``.
     Progress signal: 1.0 when integral value is produced."""
 
     name: str = "quadrature"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return "integrand" in state.derived and "interval" in state.derived
+        return "integrand" in state.V["symbolic"]["derived"] and "interval" in state.V["symbolic"]["derived"]
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         try:
             import sympy as sp
             x = sp.Symbol("x")
-            f_expr = sp.sympify(str(state.derived.get("integrand")))
-            a, b = state.derived.get("interval")
+            f_expr = sp.sympify(str(state.V["symbolic"]["derived"].get("integrand")))
+            a, b = state.V["symbolic"]["derived"].get("interval")
             val = float(sp.integrate(f_expr, (x, a, b)))
-            state.derived["integral"] = val
+            state.V["symbolic"]["derived"]["integral"] = val
             return state, 1.0
         except Exception:
             return state, 0.0
@@ -406,14 +406,14 @@ class RationalizeOperator(Operator):
     name: str = "rationalize"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return any("." in str(a) for a in state.candidate_answers)
+        return any("." in str(a) for a in state.A["symbolic"]["candidates"])
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         try:
             import sympy as sp
             new_answers = []
             changes = 0
-            for a in state.candidate_answers:
+            for a in state.A["symbolic"]["candidates"]:
                 try:
                     r = sp.Rational(str(a)).limit_denominator()
                     if str(r) != str(a):
@@ -422,7 +422,7 @@ class RationalizeOperator(Operator):
                 except Exception:
                     new_answers.append(str(a))
             if changes:
-                state.candidate_answers = new_answers
+                state.A["symbolic"]["candidates"] = new_answers
             return state, float(changes)
         except Exception:
             return state, 0.0

--- a/micro_solver/state.py
+++ b/micro_solver/state.py
@@ -1,83 +1,397 @@
 from __future__ import annotations
 
+"""State model for the micro-solver.
+
+This refactors the previous flat :class:`MicroState` into a hierarchy of
+five dictionaries representing ``R`` (representations), ``C`` (constraints),
+``V`` (variables and working memory), ``A`` (answers) and ``M`` (metrics).
+
+Legacy attribute access is preserved through property adapters so existing
+callers that expect the old flat fields continue to work.  New code should use
+the nested dictionaries directly, e.g. ``state.R['symbolic']['tokens']`` or
+``state.C['symbolic']``.
+"""
+
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
 class MicroState:
-    """Blackboard state for micro‑solver.
+    """Blackboard state for the micro‑solver.
 
     The state captures recognition artifacts (tokens, variables, relations),
     reasoning artifacts (candidate schemas, strategies, plan), and calculation
     artifacts (intermediate expressions, numeric evaluations, final answer).
 
-    Each micro‑step updates a small subset of fields and is followed by a
-    micro‑QA check to ensure pre/post‑conditions hold.
+    State data is grouped into five top level buckets following the R/C/V/A/M
+    plan:
+
+    ``R`` – representations for symbolic/numeric/alternative views
+    ``C`` – constraints/relations for each representation
+    ``V`` – variables, environment and derived data
+    ``A`` – candidate and final answers
+    ``M`` – solver metrics
+
+    ``problem_text`` and a handful of orchestration hints remain at the top
+    level for convenience.
     """
 
-    # Raw inputs
+    # ------------------------------------------------------------------
+    # raw inputs
     problem_text: str = ""
 
-    # Recognition outputs (atomic)
-    normalized_text: Optional[str] = None
-    sentences: list[str] = field(default_factory=list)
-    tokens: list[str] = field(default_factory=list)
-    tokens_per_sentence: list[list[str]] = field(default_factory=list)
-    quantities: list[dict[str, Any]] = field(default_factory=list)  # {value, unit?, sentence_idx}
-    variables: list[str] = field(default_factory=list)
-    constants: list[str] = field(default_factory=list)
-    identifiers: list[str] = field(default_factory=list)
-    points: list[str] = field(default_factory=list)
-    functions: list[str] = field(default_factory=list)
-    parameters: list[str] = field(default_factory=list)
-    relations: list[str] = field(default_factory=list)  # e.g., "2x+3=11", "x>0"
-    goal: Optional[str] = None  # e.g., "solve for x"
-    problem_type: Optional[str] = None  # e.g., "linear", "quadratic", "ratio", "geometry"...
-    canonical_repr: Optional[dict[str, Any]] = None  # structured representation
-
-    # Representations and solver control
-    representations: list[str] = field(
-        default_factory=lambda: ["symbolic", "numeric"]
+    # ------------------------------------------------------------------
+    # R/C/V/A/M containers with dual (symbolic/numeric/alt) representations
+    R: Dict[str, Dict[str, Any]] = field(
+        default_factory=lambda: {"symbolic": {}, "numeric": {}, "alt": {}}
     )
+    C: Dict[str, List[str]] = field(
+        default_factory=lambda: {"symbolic": [], "numeric": [], "alt": []}
+    )
+    V: Dict[str, Dict[str, Any]] = field(
+        default_factory=lambda: {
+            rep: {
+                "variables": [],
+                "constants": [],
+                "identifiers": [],
+                "points": [],
+                "functions": [],
+                "parameters": [],
+                "quantities": [],
+                "env": {},
+                "derived": {},
+            }
+            for rep in ("symbolic", "numeric", "alt")
+        }
+    )
+    A: Dict[str, Dict[str, Any]] = field(
+        default_factory=lambda: {
+            rep: {
+                "candidates": [],
+                "final": None,
+                "explanation": None,
+                "intermediate": [],
+                "certificate": None,
+            }
+            for rep in ("symbolic", "numeric", "alt")
+        }
+    )
+    M: Dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Solver control and reasoning artifacts (unchanged layout)
+    representations: List[str] = field(default_factory=lambda: ["symbolic", "numeric"])
     representation: str = "symbolic"
     numeric_seed: float = 0.0
-    case_splits: list[list[str]] = field(default_factory=list)
+    case_splits: List[List[str]] = field(default_factory=list)
     active_case: int = 0
 
-    # Reasoning artifacts (micro‑planned)
-    schemas: list[str] = field(default_factory=list)  # matched known schemas by name
-    strategies: list[str] = field(default_factory=list)
+    goal: Optional[str] = None  # e.g. "solve for x"
+    problem_type: Optional[str] = None  # e.g. "linear", "quadratic"
+
+    schemas: List[str] = field(default_factory=list)
+    strategies: List[str] = field(default_factory=list)
     chosen_strategy: Optional[str] = None
-    plan_steps: list[dict[str, Any]] = field(default_factory=list)  # [{id, action, target, args}]
+    plan_steps: List[Dict[str, Any]] = field(default_factory=list)
     current_step_idx: int = 0
 
-    # Working memory (calculation context)
-    env: dict[str, Any] = field(default_factory=dict)  # symbol table / bindings
-    equations: list[str] = field(default_factory=list)
-    derived: dict[str, Any] = field(default_factory=dict)
-
-    # Meta‑reasoning stats
-    eq_count: int = 0
-    ineq_count: int = 0
-    jacobian_rank: int = 0
-    degrees_of_freedom: int = 0
-    needs_replan: bool = False
-    progress_score: float = 0.0
-    stalls: int = 0
-    violations: int = 0
-
-    # Results
-    intermediate: list[dict[str, Any]] = field(default_factory=list)  # trace of {op, in, out}
-    candidate_answers: list[Any] = field(default_factory=list)
-    final_answer: Optional[Any] = None
-    final_explanation: Optional[str] = None
-    certificate: Optional[dict[str, Any]] = None
-
-    # Control / diagnostics
+    # Orchestration / diagnostics
     qa_feedback: Optional[str] = None
     error: Optional[str] = None
-
-    # Orchestration hints
     skip_qa: bool = False
-    next_steps: Optional[list] = None  # injected micro‑steps for dynamic plans
+    next_steps: Optional[List] = None
+
+    # ------------------------------------------------------------------
+    # Property adapters for legacy flat fields
+    # Representations ---------------------------------------------------
+    @property
+    def normalized_text(self) -> Optional[str]:
+        return self.R["symbolic"].get("normalized_text")
+
+    @normalized_text.setter
+    def normalized_text(self, value: Optional[str]) -> None:
+        self.R["symbolic"]["normalized_text"] = value
+
+    @property
+    def sentences(self) -> List[str]:
+        return self.R["symbolic"].setdefault("sentences", [])
+
+    @sentences.setter
+    def sentences(self, value: List[str]) -> None:
+        self.R["symbolic"]["sentences"] = value
+
+    @property
+    def tokens(self) -> List[str]:
+        return self.R["symbolic"].setdefault("tokens", [])
+
+    @tokens.setter
+    def tokens(self, value: List[str]) -> None:
+        self.R["symbolic"]["tokens"] = value
+
+    @property
+    def tokens_per_sentence(self) -> List[List[str]]:
+        return self.R["symbolic"].setdefault("tokens_per_sentence", [])
+
+    @tokens_per_sentence.setter
+    def tokens_per_sentence(self, value: List[List[str]]) -> None:
+        self.R["symbolic"]["tokens_per_sentence"] = value
+
+    @property
+    def canonical_repr(self) -> Optional[Dict[str, Any]]:
+        return self.R["symbolic"].get("canonical_repr")
+
+    @canonical_repr.setter
+    def canonical_repr(self, value: Optional[Dict[str, Any]]) -> None:
+        self.R["symbolic"]["canonical_repr"] = value
+
+    # Variables ---------------------------------------------------------
+    def _v(self, key: str) -> Any:
+        return self.V["symbolic"].setdefault(key, [])
+
+    def _set_v(self, key: str, value: Any) -> None:
+        self.V["symbolic"][key] = value
+
+    @property
+    def quantities(self) -> List[Dict[str, Any]]:
+        return self.V["symbolic"].setdefault("quantities", [])
+
+    @quantities.setter
+    def quantities(self, value: List[Dict[str, Any]]) -> None:
+        self.V["symbolic"]["quantities"] = value
+
+    @property
+    def variables(self) -> List[str]:
+        return self._v("variables")
+
+    @variables.setter
+    def variables(self, value: List[str]) -> None:
+        self._set_v("variables", value)
+
+    @property
+    def constants(self) -> List[str]:
+        return self._v("constants")
+
+    @constants.setter
+    def constants(self, value: List[str]) -> None:
+        self._set_v("constants", value)
+
+    @property
+    def identifiers(self) -> List[str]:
+        return self._v("identifiers")
+
+    @identifiers.setter
+    def identifiers(self, value: List[str]) -> None:
+        self._set_v("identifiers", value)
+
+    @property
+    def points(self) -> List[str]:
+        return self._v("points")
+
+    @points.setter
+    def points(self, value: List[str]) -> None:
+        self._set_v("points", value)
+
+    @property
+    def functions(self) -> List[str]:
+        return self._v("functions")
+
+    @functions.setter
+    def functions(self, value: List[str]) -> None:
+        self._set_v("functions", value)
+
+    @property
+    def parameters(self) -> List[str]:
+        return self._v("parameters")
+
+    @parameters.setter
+    def parameters(self, value: List[str]) -> None:
+        self._set_v("parameters", value)
+
+    @property
+    def env(self) -> Dict[str, Any]:
+        return self.V["symbolic"].setdefault("env", {})
+
+    @env.setter
+    def env(self, value: Dict[str, Any]) -> None:
+        self.V["symbolic"]["env"] = value
+
+    @property
+    def derived(self) -> Dict[str, Any]:
+        return self.V["symbolic"].setdefault("derived", {})
+
+    @derived.setter
+    def derived(self, value: Dict[str, Any]) -> None:
+        self.V["symbolic"]["derived"] = value
+
+    # Constraints -------------------------------------------------------
+    @property
+    def relations(self) -> List[str]:
+        return self.C["symbolic"]
+
+    @relations.setter
+    def relations(self, value: List[str]) -> None:
+        self.C["symbolic"] = value
+
+    @property
+    def equations(self) -> List[str]:
+        return self.C["symbolic"]
+
+    @equations.setter
+    def equations(self, value: List[str]) -> None:
+        self.C["symbolic"] = value
+
+    # Answers -----------------------------------------------------------
+    @property
+    def intermediate(self) -> List[Dict[str, Any]]:
+        return self.A["symbolic"].setdefault("intermediate", [])
+
+    @intermediate.setter
+    def intermediate(self, value: List[Dict[str, Any]]) -> None:
+        self.A["symbolic"]["intermediate"] = value
+
+    @property
+    def candidate_answers(self) -> List[Any]:
+        return self.A["symbolic"].setdefault("candidates", [])
+
+    @candidate_answers.setter
+    def candidate_answers(self, value: List[Any]) -> None:
+        self.A["symbolic"]["candidates"] = value
+
+    @property
+    def final_answer(self) -> Any:
+        return self.A["symbolic"].get("final")
+
+    @final_answer.setter
+    def final_answer(self, value: Any) -> None:
+        self.A["symbolic"]["final"] = value
+
+    @property
+    def final_explanation(self) -> Optional[str]:
+        return self.A["symbolic"].get("explanation")
+
+    @final_explanation.setter
+    def final_explanation(self, value: Optional[str]) -> None:
+        self.A["symbolic"]["explanation"] = value
+
+    @property
+    def certificate(self) -> Optional[Dict[str, Any]]:
+        return self.A["symbolic"].get("certificate")
+
+    @certificate.setter
+    def certificate(self, value: Optional[Dict[str, Any]]) -> None:
+        self.A["symbolic"]["certificate"] = value
+
+    # Metrics -----------------------------------------------------------
+    def _m_get(self, key: str, default: Any = 0) -> Any:
+        return self.M.get(key, default)
+
+    def _m_set(self, key: str, value: Any) -> None:
+        self.M[key] = value
+
+    @property
+    def eq_count(self) -> int:
+        return self._m_get("eq_count", 0)
+
+    @eq_count.setter
+    def eq_count(self, value: int) -> None:
+        self._m_set("eq_count", value)
+
+    @property
+    def ineq_count(self) -> int:
+        return self._m_get("ineq_count", 0)
+
+    @ineq_count.setter
+    def ineq_count(self, value: int) -> None:
+        self._m_set("ineq_count", value)
+
+    @property
+    def jacobian_rank(self) -> int:
+        return self._m_get("jacobian_rank", 0)
+
+    @jacobian_rank.setter
+    def jacobian_rank(self, value: int) -> None:
+        self._m_set("jacobian_rank", value)
+
+    @property
+    def degrees_of_freedom(self) -> int:
+        return self._m_get("degrees_of_freedom", 0)
+
+    @degrees_of_freedom.setter
+    def degrees_of_freedom(self, value: int) -> None:
+        self._m_set("degrees_of_freedom", value)
+
+    @property
+    def needs_replan(self) -> bool:
+        return self._m_get("needs_replan", False)
+
+    @needs_replan.setter
+    def needs_replan(self, value: bool) -> None:
+        self._m_set("needs_replan", value)
+
+    @property
+    def progress_score(self) -> float:
+        return self._m_get("progress_score", 0.0)
+
+    @progress_score.setter
+    def progress_score(self, value: float) -> None:
+        self._m_set("progress_score", value)
+
+    @property
+    def stalls(self) -> int:
+        return self._m_get("stalls", 0)
+
+    @stalls.setter
+    def stalls(self, value: int) -> None:
+        self._m_set("stalls", value)
+
+    @property
+    def violations(self) -> int:
+        return self._m_get("violations", 0)
+
+    @violations.setter
+    def violations(self, value: int) -> None:
+        self._m_set("violations", value)
+
+    # ------------------------------------------------------------------
+    # Migration helpers -------------------------------------------------
+    @classmethod
+    def from_legacy(cls, data: Dict[str, Any]) -> "MicroState":
+        """Construct a state from a flat dictionary of legacy fields."""
+
+        ms = cls()
+        for k, v in data.items():
+            if hasattr(ms, k):
+                try:
+                    setattr(ms, k, v)
+                except Exception:
+                    pass
+        return ms
+
+    def to_legacy(self) -> Dict[str, Any]:
+        """Return a flattened representation for backwards compatibility."""
+
+        return {
+            "problem_text": self.problem_text,
+            "normalized_text": self.normalized_text,
+            "sentences": self.sentences,
+            "tokens": self.tokens,
+            "tokens_per_sentence": self.tokens_per_sentence,
+            "quantities": self.quantities,
+            "variables": self.variables,
+            "constants": self.constants,
+            "identifiers": self.identifiers,
+            "points": self.points,
+            "functions": self.functions,
+            "parameters": self.parameters,
+            "relations": self.relations,
+            "goal": getattr(self, "goal", None),
+            "problem_type": getattr(self, "problem_type", None),
+            "canonical_repr": self.canonical_repr,
+            "env": self.env,
+            "derived": self.derived,
+            "candidate_answers": self.candidate_answers,
+            "final_answer": self.final_answer,
+            "final_explanation": self.final_explanation,
+        }
+

--- a/micro_solver/steps_candidate.py
+++ b/micro_solver/steps_candidate.py
@@ -12,13 +12,13 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
     expr: Optional[str] = None
     try:
         target_expr = None
-        if isinstance(state.canonical_repr, dict):
-            target_expr = state.canonical_repr.get("target")
+        if isinstance(state.R["symbolic"]["canonical_repr"], dict):
+            target_expr = state.R["symbolic"]["canonical_repr"].get("target")
         if isinstance(target_expr, str) and target_expr.strip():
-            ok_t, val_t = evaluate_with_env(target_expr, state.env or {})
+            ok_t, val_t = evaluate_with_env(target_expr, state.V["symbolic"]["env"] or {})
             if ok_t:
                 # Record as candidate only; verification will finalize if justified
-                state.candidate_answers.append(val_t)
+                state.A["symbolic"]["candidates"].append(val_t)
                 state.skip_qa = True
                 return state
     except Exception:
@@ -26,7 +26,7 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
 
     import re as _re
     eqs: list[tuple[str, str]] = []
-    for r in state.relations:
+    for r in state.C["symbolic"]:
         op, lhs, rhs = parse_relation_sides(r)
         if op == "=" and _re.search(r"=", r):
             eqs.append((lhs, rhs))
@@ -42,7 +42,7 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
             break
 
     if expr is None:
-        for r in reversed(state.relations):
+        for r in reversed(state.C["symbolic"]):
             op, lhs, rhs = parse_relation_sides(r)
             if _re.search(r"(<=|>=|!=|=|<|>)", r):
                 continue
@@ -54,15 +54,15 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
     if expr is None:
         if eqs:
             expr = eqs[-1][1].strip()
-        elif state.relations:
-            expr = state.relations[-1].strip()
+        elif state.C["symbolic"]:
+            expr = state.C["symbolic"][-1].strip()
 
     if expr is not None:
         ok_num, val_num = evaluate_numeric(expr)
         if not ok_num:
             out, err = _invoke(
                 A.CandidateSynthesizerAgent,
-                {"relations": state.relations, "goal": state.goal, "problem_type": state.problem_type, "plan_steps": state.plan_steps},
+                {"relations": state.C["symbolic"], "goal": state.goal, "problem_type": state.problem_type, "plan_steps": state.plan_steps},
                 qa_feedback=state.qa_feedback,
             )
             state.qa_feedback = None
@@ -70,9 +70,9 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
                 cand = str(out.get("candidate", "")).strip()
                 ok2, val2 = evaluate_numeric(cand)
                 if ok2:
-                    state.candidate_answers.append(val2)
+                    state.A["symbolic"]["candidates"].append(val2)
                 elif cand:
-                    state.candidate_answers.append(cand)
+                    state.A["symbolic"]["candidates"].append(cand)
             # Always skip QA for extraction; rely on verify step
             state.skip_qa = True
             return state
@@ -80,7 +80,7 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
         if isinstance(val_num, (int, float)) and float(val_num) == 0.0:
             out, err = _invoke(
                 A.CandidateSynthesizerAgent,
-                {"relations": state.relations, "goal": state.goal, "problem_type": state.problem_type, "plan_steps": state.plan_steps},
+                {"relations": state.C["symbolic"], "goal": state.goal, "problem_type": state.problem_type, "plan_steps": state.plan_steps},
                 qa_feedback=state.qa_feedback,
             )
             state.qa_feedback = None
@@ -88,18 +88,18 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
                 cand = str(out.get("candidate", "")).strip()
                 ok2, val2 = evaluate_numeric(cand)
                 if ok2 and float(val2) != 0.0:
-                    state.candidate_answers.append(val2)
+                    state.A["symbolic"]["candidates"].append(val2)
                     state.skip_qa = True
                     return state
                 if cand and cand != "0":
-                    state.candidate_answers.append(cand)
+                    state.A["symbolic"]["candidates"].append(cand)
                     state.skip_qa = True
                     return state
             # As a last resort, do not emit a trivial 0 candidate
             state.skip_qa = True
             return state
         # Numeric nonzero: store candidate only
-        state.candidate_answers.append(val_num)
+        state.A["symbolic"]["candidates"].append(val_num)
         state.skip_qa = True
         return state
 
@@ -108,18 +108,18 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
 
 
 def _micro_simplify_candidate_sympy(state: MicroState) -> MicroState:
-    if not state.candidate_answers:
+    if not state.A["symbolic"]["candidates"]:
         state.skip_qa = True
         return state
     try:
-        last_raw = state.candidate_answers[-1]
+        last_raw = state.A["symbolic"]["candidates"][-1]
         last = str(last_raw)
         simp = simplify_expr(last)
         ok, val = evaluate_numeric(simp)
         if ok:
-            state.candidate_answers[-1] = val
+            state.A["symbolic"]["candidates"][-1] = val
         else:
-            state.candidate_answers[-1] = simp
+            state.A["symbolic"]["candidates"][-1] = simp
     except Exception:
         pass
     return state
@@ -134,8 +134,8 @@ def _infer_target_var(state: MicroState) -> Optional[str]:
     except Exception:
         pass
     try:
-        if isinstance(state.canonical_repr, dict):
-            tgt = state.canonical_repr.get("target")
+        if isinstance(state.R["symbolic"]["canonical_repr"], dict):
+            tgt = state.R["symbolic"]["canonical_repr"].get("target")
             if isinstance(tgt, str) and tgt.strip():
                 if "=" in tgt:
                     lhs = tgt.split("=", 1)[0]
@@ -162,31 +162,31 @@ def _infer_target_var(state: MicroState) -> Optional[str]:
 
 
 def _micro_verify(state: MicroState) -> MicroState:
-    for cand in state.candidate_answers:
+    for cand in state.A["symbolic"]["candidates"]:
         out, err = _invoke(
             A.VerifyAgent,
-            {"relations": state.relations, "candidate": cand, "goal": state.goal, "problem_type": state.problem_type},
+            {"relations": state.C["symbolic"], "candidate": cand, "goal": state.goal, "problem_type": state.problem_type},
             qa_feedback=state.qa_feedback,
         )
         if err:
             continue
         if bool(out.get("ok", False)):
-            state.final_answer = cand
+            state.A["symbolic"]["final"] = cand
             break
     # Do not set final_answer on fallback; leave decision to verification success only
     return state
 
 
 def _micro_verify_sympy(state: MicroState) -> MicroState:
-    if not state.candidate_answers:
+    if not state.A["symbolic"]["candidates"]:
         state.skip_qa = True
         return state
     var = _infer_target_var(state)
-    for cand in list(state.candidate_answers):
+    for cand in list(state.A["symbolic"]["candidates"]):
         s = str(cand)
-        if verify_candidate(state.relations, s, varname=var):
+        if verify_candidate(state.C["symbolic"], s, varname=var):
             ok, val = evaluate_numeric(s)
-            state.final_answer = (val if ok else s)
+            state.A["symbolic"]["final"] = (val if ok else s)
             return state
     return _micro_verify(state)
 
@@ -199,11 +199,11 @@ def _micro_solve_sympy(state: MicroState) -> MicroState:
     target = _infer_target_var(state)
     sols: list[str] = []
     if target:
-        sols = solve_for(state.relations, target)
+        sols = solve_for(state.C["symbolic"], target)
     if not sols:
-        sols = solve_any(state.relations)
+        sols = solve_any(state.C["symbolic"])
     if sols:
-        state.candidate_answers.append(str(sols[-1]))
+        state.A["symbolic"]["candidates"].append(str(sols[-1]))
     else:
         state.skip_qa = True
     return state

--- a/micro_solver/steps_meta.py
+++ b/micro_solver/steps_meta.py
@@ -19,11 +19,16 @@ def _micro_monitor_dof(state: MicroState) -> MicroState:
     of freedom.  The result is stored on the state for downstream heuristics.
     """
 
-    unknowns = [v for v in state.variables + state.parameters if v not in state.env]
-    eq_relations = [r for r in state.relations if "=" in r] + list(state.equations)
+    sym_vars = state.V["symbolic"].get("variables", [])
+    sym_params = state.V["symbolic"].get("parameters", [])
+    env = state.V["symbolic"].get("env", {})
+    unknowns = [v for v in sym_vars + sym_params if v not in env]
+    eq_relations = [r for r in state.C["symbolic"] if "=" in r]
     eq_count = len(eq_relations)
     ineq_count = sum(
-        1 for r in state.relations if any(op in r for op in ("<", ">", "≤", "≥")) and "=" not in r
+        1
+        for r in state.C["symbolic"]
+        if any(op in r for op in ("<", ">", "≤", "≥")) and "=" not in r
     )
 
     rank = estimate_jacobian_rank(eq_relations, unknowns)

--- a/micro_solver/steps_reasoning.py
+++ b/micro_solver/steps_reasoning.py
@@ -8,7 +8,7 @@ from .steps_util import _invoke
 def _micro_schema(state: MicroState) -> MicroState:
     payload = {
         "type": state.problem_type,
-        "relations": state.relations,
+        "relations": state.C["symbolic"],
         "target": state.goal,
     }
     out, err = _invoke(A.SchemaRetrieverAgent, payload, qa_feedback=state.qa_feedback)
@@ -23,7 +23,7 @@ def _micro_schema(state: MicroState) -> MicroState:
 def _micro_strategies(state: MicroState) -> MicroState:
     out, err = _invoke(
         A.StrategyEnumeratorAgent,
-        {"schemas": state.schemas, "relations": state.relations, "target": state.goal},
+        {"schemas": state.schemas, "relations": state.C["symbolic"], "target": state.goal},
         qa_feedback=state.qa_feedback,
     )
     state.qa_feedback = None
@@ -38,7 +38,7 @@ def _micro_choose_strategy(state: MicroState) -> MicroState:
     for s in state.strategies or []:
         out, err = _invoke(
             A.PreconditionCheckerAgent,
-            {"strategy": s, "relations": state.relations},
+            {"strategy": s, "relations": state.C["symbolic"]},
             qa_feedback=state.qa_feedback,
         )
         if err:


### PR DESCRIPTION
## Summary
- refactor MicroState into nested dictionaries for representations, constraints, variables, answers, and metrics
- update micro-steps and operators to use new structured fields
- add legacy migration helpers for backward compatibility

## Testing
- `pytest` (fails: No module named 'sympy'; missing matplotlib; assertion failures)


------
https://chatgpt.com/codex/tasks/task_e_68b64ae4c7608330a5de7056f9cc4267