### PR TITLE
Enhance micro-solver metrics and operator scheduling

### DIFF
--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Progress‑driven operator scheduler for the micro‑solver rebuild."""
 
+import math
 import random
 from typing import Sequence
 
@@ -9,13 +10,107 @@ from .state import MicroState
 from .operators import Operator, DEFAULT_OPERATORS
 from .steps_meta import _micro_monitor_dof
 from .certificate import build_certificate
+from .sym_utils import parse_relation_sides, evaluate_with_env, evaluate_numeric
+
+
+def _total_residual_l2(state: MicroState) -> float:
+    vals: list[float] = []
+    for rel in state.relations:
+        op, lhs, rhs = parse_relation_sides(rel)
+        if op != "=":
+            continue
+        ok_l, val_l = evaluate_with_env(lhs, state.env)
+        if not ok_l:
+            ok_l, val_l = evaluate_numeric(lhs)
+        ok_r, val_r = evaluate_with_env(rhs, state.env)
+        if not ok_r:
+            ok_r, val_r = evaluate_numeric(rhs)
+        if ok_l and ok_r:
+            try:
+                vals.append(abs(float(val_l) - float(val_r)))
+            except Exception:
+                continue
+    return float(math.sqrt(sum(v * v for v in vals)))
+
+
+def _count_satisfied_ineq(state: MicroState) -> int:
+    count = 0
+    for rel in state.relations:
+        op, lhs, rhs = parse_relation_sides(rel)
+        if op not in ("<", "<=", ">", ">="):
+            continue
+        ok_l, val_l = evaluate_with_env(lhs, state.env)
+        if not ok_l:
+            ok_l, val_l = evaluate_numeric(lhs)
+        ok_r, val_r = evaluate_with_env(rhs, state.env)
+        if not ok_r:
+            ok_r, val_r = evaluate_numeric(rhs)
+        if not (ok_l and ok_r):
+            continue
+        try:
+            if op == "<" and val_l < val_r:
+                count += 1
+            elif op == "<=" and val_l <= val_r:
+                count += 1
+            elif op == ">" and val_l > val_r:
+                count += 1
+            elif op == ">=" and val_l >= val_r:
+                count += 1
+        except Exception:
+            continue
+    return count
+
+
+def _bounds_volume(bounds: dict[str, tuple[float | None, float | None]] | None) -> float:
+    if not bounds:
+        return 0.0
+    vol = 1.0
+    any_bound = False
+    for low, high in bounds.values():
+        if low is None or high is None:
+            continue
+        any_bound = True
+        try:
+            span = float(high) - float(low)
+        except Exception:
+            span = 0.0
+        if span < 0:
+            span = 0.0
+        vol *= span
+    return float(vol if any_bound else 0.0)
 
 
 def update_metrics(state: MicroState) -> MicroState:
     """Refresh solver metrics like degrees of freedom and progress score."""
 
     state = _micro_monitor_dof(state)
-    state.progress_score = float(-abs(state.degrees_of_freedom))
+    metrics = dict(getattr(state, "M", {}))
+
+    prev_res = metrics.get("residual_l2")
+    res = _total_residual_l2(state)
+    metrics["residual_l2"] = res
+    metrics["residual_l2_change"] = (
+        float(prev_res - res) if prev_res is not None else 0.0
+    )
+
+    ineq = _count_satisfied_ineq(state)
+    metrics["ineq_satisfied"] = float(ineq)
+
+    prev_vol = metrics.get("bounds_volume")
+    vol = _bounds_volume(state.derived.get("bounds"))
+    metrics["bounds_volume"] = vol
+    metrics["bounds_volume_reduction"] = (
+        float(prev_vol - vol) if prev_vol is not None else 0.0
+    )
+
+    state.M = metrics
+
+    state.progress_score = float(
+        -abs(state.degrees_of_freedom)
+        + metrics.get("residual_l2_change", 0.0)
+        + metrics.get("ineq_satisfied", 0.0)
+        + metrics.get("bounds_volume_reduction", 0.0)
+    )
     return state
 
 
@@ -24,15 +119,22 @@ def goal_satisfied(state: MicroState) -> bool:
 
 
 def select_operator(state: MicroState, operators: Sequence[Operator]) -> Operator | None:
-    """Pick the first applicable operator."""
+    """Pick the applicable operator with the highest score."""
 
+    best_op: Operator | None = None
+    best_score = float("-inf")
     for op in operators:
         try:
-            if op.applicable(state):
-                return op
+            if not op.applicable(state):
+                continue
+            score_fn = getattr(op, "score", None)
+            score = float(score_fn(state)) if callable(score_fn) else 0.0
+            if score > best_score:
+                best_score = score
+                best_op = op
         except Exception:
             continue
-    return None
+    return best_op
 
 
 def replan(state: MicroState) -> MicroState:

--- a/micro_solver/state.py
+++ b/micro_solver/state.py
@@ -66,6 +66,7 @@ class MicroState:
     progress_score: float = 0.0
     stalls: int = 0
     violations: int = 0
+    M: dict[str, float] = field(default_factory=dict)
 
     # Results
     intermediate: list[dict[str, Any]] = field(default_factory=list)  # trace of {op, in, out}

--- a/tests/test_scheduler_metrics.py
+++ b/tests/test_scheduler_metrics.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from micro_solver.scheduler import update_metrics, select_operator
+from micro_solver.state import MicroState
+from micro_solver.operators import Operator
+
+
+class BaselineOp(Operator):
+    name = "base"
+
+    def applicable(self, state: MicroState) -> bool:
+        return True
+
+    def apply(self, state: MicroState):
+        return state, 0.0
+
+
+class MetricOp(Operator):
+    name = "metric"
+
+    def applicable(self, state: MicroState) -> bool:
+        return True
+
+    def apply(self, state: MicroState):
+        return state, 0.0
+
+    def score(self, state: MicroState) -> float:
+        return state.M.get("ineq_satisfied", 0.0)
+
+
+def test_update_metrics_tracks_progress() -> None:
+    state = MicroState(
+        relations=["x = 3", "x >= 0", "x <= 10"],
+        variables=["x"],
+        env={"x": 5},
+        derived={"bounds": {"x": (0.0, 10.0)}},
+    )
+    state = update_metrics(state)
+    assert state.M["residual_l2"] == pytest.approx(2.0)
+    assert state.M["residual_l2_change"] == pytest.approx(0.0)
+    assert state.M["ineq_satisfied"] == pytest.approx(2.0)
+    assert state.M["bounds_volume"] == pytest.approx(10.0)
+    p1 = state.progress_score
+
+    state.env["x"] = 3
+    state.derived["bounds"]["x"] = (0.0, 8.0)
+    state = update_metrics(state)
+    assert state.M["residual_l2"] == pytest.approx(0.0)
+    assert state.M["residual_l2_change"] == pytest.approx(2.0)
+    assert state.M["bounds_volume_reduction"] == pytest.approx(2.0)
+    assert state.progress_score > p1
+
+
+def test_select_operator_uses_metric_scores() -> None:
+    state = MicroState()
+    state.M["ineq_satisfied"] = 5.0
+    ops = [BaselineOp(), MetricOp()]
+    chosen = select_operator(state, ops)
+    assert isinstance(chosen, MetricOp)
+
+    state.M["ineq_satisfied"] = 0.0
+    chosen = select_operator(state, ops)
+    assert isinstance(chosen, BaselineOp)


### PR DESCRIPTION
## Summary
- Track residual norm, inequality satisfaction, and bound-volume metrics in `MicroState.M`
- Use richer metrics for progress scoring and to score operators during scheduling
- Test metric tracking and metric-aware operator selection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b64b0ff9b48330a4b580bffcbb98e7