### PR TITLE
Add constraint analysis and rank repair utilities

### DIFF
--- a/docs/micro_solver.md
+++ b/docs/micro_solver.md
@@ -71,6 +71,7 @@ Options:
 
 - Iteration: `scheduler.solve_with_defaults` iteratively applies operators guided by progress metrics; a stall counter guards against infinite loops.
 - SymPy integration: `micro_solver/sym_utils.py` provides `simplify_expr` and `verify_candidate`. These helpers are defensive and degrade gracefully if SymPy is not available.
+- Constraint analysis: `micro_solver.constraint_analysis` computes numeric Jacobians, flags redundant constraints, and attempts simple rank repairs before invoking expensive solves.
 
 Plan Lint (Policy Tester)
 -------------------------

--- a/micro_solver/README.md
+++ b/micro_solver/README.md
@@ -62,6 +62,7 @@ Deterministic Helpers
 - `verify_candidate`: equality/inequality substitution checks for a candidate
 - `rewrite_relations`: atomic “both‑sides” operations (add/sub/mul/div), substitute, expand, factor, simplify
 - `solve_for`: direct SymPy solve for the inferred target variable
+- `constraint_analysis`: numeric Jacobian and rank-repair helpers used before expensive solves
 
 Plan Lint (Policy Tester)
 -------------------------

--- a/micro_solver/__init__.py
+++ b/micro_solver/__init__.py
@@ -26,6 +26,10 @@ from .operators import (
     DEFAULT_OPERATORS,
 )  # noqa: F401
 from .scheduler import solve, solve_with_defaults  # noqa: F401
+from .constraint_analysis import (  # noqa: F401
+    mark_redundant_constraints,
+    attempt_rank_repair,
+)
 
 __all__ = [
     "MicroState",
@@ -43,5 +47,7 @@ __all__ = [
     "DEFAULT_OPERATORS",
     "solve",
     "solve_with_defaults",
+    "mark_redundant_constraints",
+    "attempt_rank_repair",
 ]
 

--- a/micro_solver/constraint_analysis.py
+++ b/micro_solver/constraint_analysis.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+"""Utilities for analysing constraint independence and repairing rank issues.
+
+This module provides small helpers that operate on relation strings used by the
+micro‑solver. The functions avoid heavy symbolic manipulation where possible and
+fall back to conservative heuristics when SymPy is unavailable.
+
+Example workflow::
+
+    jac = numeric_jacobian(relations, variables)
+    redundant = mark_redundant_constraints(relations, variables)
+    repaired, info = attempt_rank_repair(relations, variables)
+
+``numeric_jacobian`` computes the Jacobian matrix for equality relations with
+respect to the provided variables. ``mark_redundant_constraints`` uses that
+Jacobian to detect linearly dependent rows. ``attempt_rank_repair`` drops those
+rows and tries simple substitutions to keep the system well determined.
+"""
+
+from typing import Sequence, Tuple, Dict, Any, Optional
+
+
+def _collect_symbols(relations: Sequence[str]) -> list[str]:
+    """Return sorted list of symbols appearing in equality relations."""
+    try:
+        from .sym_utils import parse_relation_sides, _parse_expr
+    except Exception:  # SymPy unavailable or import failure
+        return []
+
+    syms: set[str] = set()
+    for r in relations:
+        try:
+            op, lhs, rhs = parse_relation_sides(r)
+            if op != "=":
+                continue
+            expr = _parse_expr(lhs) - _parse_expr(rhs)
+            syms.update(str(s) for s in getattr(expr, "free_symbols", set()))
+        except Exception:
+            continue
+    return sorted(syms)
+
+
+def numeric_jacobian(
+    relations: Sequence[str],
+    variables: Optional[Sequence[str]] = None,
+    env: Optional[Dict[str, Any]] = None,
+):
+    """Return numeric Jacobian matrix for equality relations.
+
+    The Jacobian is evaluated at ``env`` when provided, otherwise at zeros. When
+    SymPy is unavailable, ``None`` is returned.
+    """
+    try:
+        import sympy as sp
+        from .sym_utils import parse_relation_sides, _parse_expr
+    except Exception:
+        return None
+
+    vars_list = list(variables) if variables else _collect_symbols(relations)
+    exprs = []
+    for r in relations:
+        op, lhs, rhs = parse_relation_sides(r)
+        if op != "=":
+            continue
+        try:
+            exprs.append(_parse_expr(lhs) - _parse_expr(rhs))
+        except Exception:
+            continue
+    if not exprs or not vars_list:
+        return sp.Matrix([])
+
+    syms = [sp.Symbol(v) for v in vars_list]
+    J = sp.Matrix(exprs).jacobian(syms)
+    subs: Dict[Any, Any] = {}
+    if env:
+        for v in vars_list:
+            val = env.get(v)
+            if isinstance(val, (int, float)):
+                subs[sp.Symbol(v)] = float(val)
+    if subs:
+        J = J.subs(subs)
+    return J.applyfunc(lambda e: e.evalf())
+
+
+def mark_redundant_constraints(
+    relations: Sequence[str],
+    variables: Optional[Sequence[str]] = None,
+    env: Optional[Dict[str, Any]] = None,
+) -> list[int]:
+    """Return indices of relations that appear linearly dependent.
+
+    The detection is based on the row rank of the Jacobian. When rank
+    computation fails, an empty list is returned.
+    """
+    try:
+        import sympy as sp
+    except Exception:
+        return []
+
+    J = numeric_jacobian(relations, variables, env)
+    if J is None or J.rows == 0:
+        return []
+    try:
+        _, pivots = J.T.rref()  # pivot columns of transpose = independent rows
+        independent = set(pivots)
+        return [i for i in range(J.rows) if i not in independent]
+    except Exception:
+        return []
+
+
+def attempt_rank_repair(
+    relations: Sequence[str],
+    variables: Optional[Sequence[str]] = None,
+    env: Optional[Dict[str, Any]] = None,
+) -> Tuple[list[str], Dict[str, Any]]:
+    """Remove redundant constraints and attempt simple substitutions.
+
+    Returns ``(new_relations, info)`` where ``info`` records removed relations
+    and any substitutions performed.
+    """
+    vars_list = list(variables) if variables else _collect_symbols(relations)
+    redundant = mark_redundant_constraints(relations, vars_list, env)
+    if not redundant:
+        return list(relations), {"removed": [], "substitutions": {}}
+
+    new_rel = [r for i, r in enumerate(relations) if i not in redundant]
+    subs: Dict[str, str] = {}
+
+    try:
+        import sympy as sp
+        from .sym_utils import parse_relation_sides, _parse_expr, rewrite_relations
+    except Exception:
+        return new_rel, {"removed": [relations[i] for i in redundant], "substitutions": {}}
+
+    for idx in redundant:
+        r = relations[idx]
+        op, lhs, rhs = parse_relation_sides(r)
+        if op != "=":
+            continue
+        eq = _parse_expr(lhs) - _parse_expr(rhs)
+        for v in vars_list:
+            sym = sp.Symbol(v)
+            try:
+                sol = sp.solve(eq, sym)
+                if sol:
+                    subs[v] = sp.sstr(sol[0])
+                    break
+            except Exception:
+                continue
+    if subs:
+        try:
+            new_rel = rewrite_relations(
+                new_rel,
+                {"action": "substitute", "args": {"replacements": subs}},
+            )
+        except Exception:
+            pass
+    return new_rel, {"removed": [relations[i] for i in redundant], "substitutions": subs}

--- a/micro_solver/sym_utils.py
+++ b/micro_solver/sym_utils.py
@@ -505,6 +505,12 @@ def solve_for(relations: list[str], target: Optional[str]) -> list[str]:
     """
     if not target:
         return []
+    # Attempt rank repair before invoking heavy solves
+    try:
+        from .constraint_analysis import attempt_rank_repair
+        relations, _ = attempt_rank_repair(relations)
+    except Exception:
+        pass
     try:
         import sympy as sp
         sym = sp.Symbol(str(target))
@@ -552,6 +558,12 @@ def solve_any(relations: list[str]) -> list[str]:
     Returns a list of solution expressions (as strings) that are fully determined
     (i.e., have no free symbols). On failure, returns [].
     """
+    # Attempt rank repair before heavy solving
+    try:
+        from .constraint_analysis import attempt_rank_repair
+        relations, _ = attempt_rank_repair(relations)
+    except Exception:
+        pass
     try:
         import sympy as sp
     except Exception:

--- a/tests/test_constraint_analysis.py
+++ b/tests/test_constraint_analysis.py
@@ -1,0 +1,17 @@
+from micro_solver.constraint_analysis import (
+    mark_redundant_constraints,
+    attempt_rank_repair,
+)
+
+
+def test_mark_redundant_constraints_detects_dependency() -> None:
+    rels = ["x + y = 2", "2x + 2y = 4", "x - y = 0"]
+    redundant = mark_redundant_constraints(rels, ["x", "y"])
+    assert redundant == [1]
+
+
+def test_attempt_rank_repair_removes_redundant() -> None:
+    rels = ["x + y = 2", "2x + 2y = 4", "x - y = 0"]
+    repaired, info = attempt_rank_repair(rels, ["x", "y"])
+    assert len(repaired) == 2
+    assert info["removed"] == ["2x + 2y = 4"]


### PR DESCRIPTION
## Summary
- add `constraint_analysis` module with numeric Jacobian computation, redundancy detection, and rank-repair helpers
- integrate constraint checks before SymPy solves and expose helpers through package API
- document constraint analysis utilities and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b64b388a4883309bea0d3affe82c32