### PR TITLE
Handle missing canonical representation in planner flow

### DIFF
--- a/micro_solver/steps_candidate.py
+++ b/micro_solver/steps_candidate.py
@@ -12,8 +12,9 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
     expr: Optional[str] = None
     try:
         target_expr = None
-        if isinstance(state.R["symbolic"]["canonical_repr"], dict):
-            target_expr = state.R["symbolic"]["canonical_repr"].get("target")
+        cr = state.canonical_repr
+        if isinstance(cr, dict):
+            target_expr = cr.get("target")
         if isinstance(target_expr, str) and target_expr.strip():
             ok_t, val_t = evaluate_with_env(target_expr, state.V["symbolic"]["env"] or {})
             if ok_t:
@@ -134,8 +135,9 @@ def _infer_target_var(state: MicroState) -> Optional[str]:
     except Exception:
         pass
     try:
-        if isinstance(state.R["symbolic"]["canonical_repr"], dict):
-            tgt = state.R["symbolic"]["canonical_repr"].get("target")
+        cr = state.canonical_repr
+        if isinstance(cr, dict):
+            tgt = cr.get("target")
             if isinstance(tgt, str) and tgt.strip():
                 if "=" in tgt:
                     lhs = tgt.split("=", 1)[0]

--- a/micro_solver/steps_execution.py
+++ b/micro_solver/steps_execution.py
@@ -52,12 +52,13 @@ def _micro_execute_plan(state: MicroState, *, max_iters: Optional[int] = None) -
 
         base_hist = [{"action": (st or {}).get("action")} for st in (state.plan_steps or [])]
         hist = base_hist + [{"action": h.get("action"), "ok": h.get("ok"), "reason": h.get("reason")} for h in atomic_history]
+        cr = state.canonical_repr
         ap_out, ap_err = _invoke(
             A.AtomicPlannerAgent,
             {
                 "relations": state.C["symbolic"],
                 "goal": state.goal,
-                "canonical_target": (state.R["symbolic"]["canonical_repr"] or {}).get("target") if isinstance(state.R["symbolic"]["canonical_repr"], dict) else None,
+                "canonical_target": (cr or {}).get("target") if isinstance(cr, dict) else None,
                 "env": state.V["symbolic"]["env"],
                 "history": hist,
             },

--- a/micro_solver/steps_execution_utils.py
+++ b/micro_solver/steps_execution_utils.py
@@ -28,8 +28,9 @@ def maybe_eval_target(state: MicroState) -> bool:
     """Evaluate the target expression and record candidate answers."""
     try:
         target_expr = None
-        if isinstance(state.R["symbolic"]["canonical_repr"], dict):
-            target_expr = state.R["symbolic"]["canonical_repr"].get("target")
+        cr = state.canonical_repr
+        if isinstance(cr, dict):
+            target_expr = cr.get("target")
         if isinstance(target_expr, str) and target_expr.strip():
             ok, val = evaluate_with_env(target_expr, state.V["symbolic"]["env"] or {})
             if ok:
@@ -96,7 +97,8 @@ def target_symbols(state: MicroState) -> set[str]:
             standard_transformations,
         )
         transformations = (*standard_transformations, implicit_multiplication_application)
-        tgt = (state.R["symbolic"]["canonical_repr"] or {}).get("target") if isinstance(state.R["symbolic"]["canonical_repr"], dict) else None
+        cr = state.canonical_repr
+        tgt = (cr or {}).get("target") if isinstance(cr, dict) else None
         if isinstance(tgt, str) and tgt.strip():
             expr = parse_expr(tgt, transformations=transformations)
             return {str(s) for s in getattr(expr, "free_symbols", set())}
@@ -210,7 +212,8 @@ def progress_metrics(state: MicroState) -> tuple[float, int, int, int, int, int,
     except Exception:
         pass
     try:
-        target_expr = (state.R["symbolic"]["canonical_repr"] or {}).get("target") if isinstance(state.R["symbolic"]["canonical_repr"], dict) else None
+        cr = state.canonical_repr
+        target_expr = (cr or {}).get("target") if isinstance(cr, dict) else None
         if isinstance(target_expr, str) and target_expr.strip():
             ok, _ = evaluate_with_env(target_expr, state.V["symbolic"]["env"] or {})
             if ok:


### PR DESCRIPTION
## Summary
- Avoid KeyError when canonical representation is absent by using `state.canonical_repr`
- Safely access canonical targets in execution helpers and candidate extraction

## Testing
- `pre-commit run --files micro_solver/steps_execution.py micro_solver/steps_execution_utils.py micro_solver/steps_candidate.py` *(fails: flake8 and mypy errors)*
- `pytest` *(fails: 8 failed, 90 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6639a431083308d2a165c9b0b40b8