### PR TITLE
Fix redundant constraint removal with preceding inequalities

### DIFF
--- a/tests/test_constraint_analysis.py
+++ b/tests/test_constraint_analysis.py
@@ -15,3 +15,12 @@ def test_attempt_rank_repair_removes_redundant() -> None:
     repaired, info = attempt_rank_repair(rels, ["x", "y"])
     assert len(repaired) == 2
     assert info["removed"] == ["2x + 2y = 4"]
+
+
+def test_inequality_does_not_shift_indices() -> None:
+    rels = ["x >= 0", "x + y = 2", "2x + 2y = 4"]
+    redundant = mark_redundant_constraints(rels, ["x", "y"])
+    assert redundant == [2]
+    repaired, info = attempt_rank_repair(rels, ["x", "y"])
+    assert repaired == ["x >= 0", "x + y = 2"]
+    assert info["removed"] == ["2x + 2y = 4"]


### PR DESCRIPTION
## Summary
- Track original relation indices in `mark_redundant_constraints`
- Prevent incorrect constraint removal when non-equalities precede equalities
- Test that inequalities don't shift redundancy indices

## Testing
- `python -m pytest tests/test_constraint_analysis.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b66af891d883308bf7f01bfbcf1721