### PR TITLE
feat: support domain constraints in micro solver

### DIFF
--- a/micro_solver/state.py
+++ b/micro_solver/state.py
@@ -56,6 +56,9 @@ class MicroState:
     env: dict[str, Any] = field(default_factory=dict)  # symbol table / bindings
     equations: list[str] = field(default_factory=list)
     derived: dict[str, Any] = field(default_factory=dict)
+    # Domain knowledge extracted from constraints
+    domain: dict[str, tuple[float | None, float | None]] = field(default_factory=dict)
+    qual: dict[str, set[str]] = field(default_factory=dict)
 
     # Meta‑reasoning stats
     eq_count: int = 0


### PR DESCRIPTION
## Summary
- track variable domains and qualitative tags in micro-solver state
- infer and prune bounds via new operators and smarter sampling
- test inequality-aware sampling and pruning behaviors

## Testing
- `SKIP=mypy pre-commit run --files micro_solver/state.py micro_solver/operators.py tests/test_extra_operators.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b66bbe771c833089ba0b0f2fef84cb