### PR TITLE
Add differentiation and integration operators

### DIFF
--- a/micro_solver/operators.py
+++ b/micro_solver/operators.py
@@ -255,6 +255,84 @@ class TransformOperator(Operator):
 
 
 @dataclass
+class DiffOperator(Operator):
+    """Differentiate a derived expression.
+
+    Expects ``state.derived['expression']`` as a SymPy parsable string and an
+    optional ``state.derived['variable']`` (defaults to ``x``).  The derivative
+    is stored in ``state.derived['derivative']``.
+
+    Progress signal: change in string length between the original expression
+    and the derivative (positive when the derivative is shorter).
+    """
+
+    name: str = "diff"
+
+    def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
+        deriv = state.derived
+        return isinstance(deriv, dict) and "expression" in deriv
+
+    def apply(self, state: MicroState) -> Tuple[MicroState, float]:
+        deriv = state.derived
+        expr = deriv.get("expression") if isinstance(deriv, dict) else None
+        if expr is None:
+            return state, 0.0
+        try:
+            import sympy as sp
+
+            var = deriv.get("variable", "x") if isinstance(deriv, dict) else "x"
+            sym = sp.Symbol(str(var))
+            expr_sym = sp.sympify(str(expr))
+            deriv = sp.diff(expr_sym, sym)
+            result = sp.sstr(deriv)
+            if isinstance(state.derived, dict):
+                state.derived["derivative"] = result
+            delta = float(len(str(expr)) - len(result))
+            return state, delta
+        except Exception:
+            return state, 0.0
+
+
+@dataclass
+class IntegrateOperator(Operator):
+    """Integrate a derived expression symbolically.
+
+    Expects ``state.derived['expression']`` as a SymPy parsable string and an
+    optional ``state.derived['variable']`` (defaults to ``x``).  The antiderivative
+    is stored in ``state.derived['integral']``.
+
+    Progress signal: change in string length between the original expression
+    and the integral (positive when the integral is shorter).
+    """
+
+    name: str = "integrate"
+
+    def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
+        deriv = state.derived
+        return isinstance(deriv, dict) and "expression" in deriv
+
+    def apply(self, state: MicroState) -> Tuple[MicroState, float]:
+        deriv = state.derived
+        expr = deriv.get("expression") if isinstance(deriv, dict) else None
+        if expr is None:
+            return state, 0.0
+        try:
+            import sympy as sp
+
+            var = deriv.get("variable", "x") if isinstance(deriv, dict) else "x"
+            sym = sp.Symbol(str(var))
+            expr_sym = sp.sympify(str(expr))
+            integ = sp.integrate(expr_sym, sym)
+            result = sp.sstr(integ)
+            if isinstance(state.derived, dict):
+                state.derived["integral"] = result
+            delta = float(len(str(expr)) - len(result))
+            return state, delta
+        except Exception:
+            return state, 0.0
+
+
+@dataclass
 class CaseSplitOperator(Operator):
     """Split simple squared equalities into linear cases.
 
@@ -511,4 +589,6 @@ DEFAULT_OPERATORS: list[Operator] = [
     GridRefineOperator(),
     QuadratureOperator(),
     RationalizeOperator(),
+    DiffOperator(),
+    IntegrateOperator(),
 ]

--- a/tests/test_diff_integrate_operator.py
+++ b/tests/test_diff_integrate_operator.py
@@ -1,0 +1,32 @@
+import pytest
+
+from micro_solver.state import MicroState
+from micro_solver.operators import DiffOperator, IntegrateOperator, DEFAULT_OPERATORS
+
+
+def test_diff_operator_computes_derivative_and_progress() -> None:
+    state = MicroState()
+    state.derived = {}
+    op = DiffOperator()
+    assert not op.applicable(state)
+    state.derived["expression"] = "x**2"
+    assert op.applicable(state)
+    state, delta = op.apply(state)
+    assert state.derived["derivative"] == "2*x"
+    assert delta == float(len("x**2") - len("2*x"))
+
+
+def test_integrate_operator_computes_integral_and_progress() -> None:
+    state = MicroState()
+    state.derived = {}
+    state.derived["expression"] = "2*x"
+    op = IntegrateOperator()
+    assert op.applicable(state)
+    state, delta = op.apply(state)
+    assert state.derived["integral"] == "x**2"
+    assert delta == float(len("2*x") - len("x**2"))
+
+
+def test_default_operators_include_new_ones() -> None:
+    assert any(isinstance(o, DiffOperator) for o in DEFAULT_OPERATORS)
+    assert any(isinstance(o, IntegrateOperator) for o in DEFAULT_OPERATORS)


### PR DESCRIPTION
## Summary
- implement `DiffOperator` and `IntegrateOperator` for symbolic differentiation and integration with progress scoring
- include operators in `DEFAULT_OPERATORS`
- add unit tests for differentiation and integration operators and default registration

## Testing
- `pytest tests/test_diff_integrate_operator.py -q`
- `pytest tests/test_extra_operators.py::test_eliminate_operator_removes_symbol -q`


------
https://chatgpt.com/codex/tasks/task_e_68b696a9f6a48330bf9a7e67841ae014