### PR TITLE
Flag under- and over-constrained states in scheduler

### DIFF
--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -105,6 +105,18 @@ def update_metrics(state: MicroState) -> MicroState:
 
     state.M = metrics
 
+    dof = state.degrees_of_freedom
+    single_goal = bool(state.goal) or len(state.V["symbolic"].get("variables", [])) == 1
+    if dof > 0 and single_goal:
+        state.needs_replan = True
+        state.status = "under-determined"
+    else:
+        state.needs_replan = False
+        if dof < 0 or (dof == 0 and res > 0):
+            state.status = "over-constrained"
+        else:
+            state.status = None
+
     state.progress_score = float(
         -abs(state.degrees_of_freedom)
         + metrics.get("residual_l2_change", 0.0)

--- a/micro_solver/state.py
+++ b/micro_solver/state.py
@@ -381,6 +381,17 @@ class MicroState:
     def violations(self, value: int) -> None:
         self._m_set("violations", value)
 
+    @property
+    def status(self) -> Optional[str]:
+        return self._m_get("status", None)
+
+    @status.setter
+    def status(self, value: Optional[str]) -> None:
+        if value is None:
+            self.M.pop("status", None)
+        else:
+            self._m_set("status", value)
+
     # ------------------------------------------------------------------
     # Migration helpers -------------------------------------------------
     @classmethod


### PR DESCRIPTION
## Summary
- detect under-determined and over-constrained micro-solver states based on DOF and residuals
- expose solver status via `MicroState.status`
- test that under-determined states trigger replanning and over-constrained states are flagged

## Testing
- `pytest tests/test_scheduler_metrics.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib', KeyError: 'payload', and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b696cd964483309e68ef18870d0fc2