### PR TITLE
Add heuristic scoring and deterministic tie-breaking to micro solver

### DIFF
--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import random
+from copy import deepcopy
 from typing import Sequence
 
 from .state import MicroState
@@ -125,6 +126,7 @@ def select_operator(state: MicroState, operators: Sequence[Operator]) -> Operato
 
     best_op: Operator | None = None
     best_score = float("-inf")
+    best_delta = float("-inf")
     for op in operators:
         try:
             if not op.applicable(state):
@@ -133,7 +135,17 @@ def select_operator(state: MicroState, operators: Sequence[Operator]) -> Operato
             score = float(score_fn(state)) if callable(score_fn) else 0.0
             if score > best_score:
                 best_score = score
+                state_copy = deepcopy(state)
+                _, delta = op.apply(state_copy)
+                best_delta = float(delta)
                 best_op = op
+            elif score == best_score:
+                state_copy = deepcopy(state)
+                _, delta = op.apply(state_copy)
+                delta = float(delta)
+                if best_delta <= 0 and delta > 0:
+                    best_delta = delta
+                    best_op = op
         except Exception:
             continue
     return best_op

--- a/tests/test_scheduler_metrics.py
+++ b/tests/test_scheduler_metrics.py
@@ -30,6 +30,26 @@ class MetricOp(Operator):
         return state.M.get("ineq_satisfied", 0.0)
 
 
+class ZeroDeltaOp(Operator):
+    name = "zero"
+
+    def applicable(self, state: MicroState) -> bool:
+        return True
+
+    def apply(self, state: MicroState):
+        return state, 0.0
+
+
+class PositiveDeltaOp(Operator):
+    name = "positive"
+
+    def applicable(self, state: MicroState) -> bool:
+        return True
+
+    def apply(self, state: MicroState):
+        return state, 1.0
+
+
 def test_update_metrics_tracks_progress() -> None:
     state = MicroState()
     state.C["symbolic"] = ["x = 3", "x >= 0", "x <= 10"]
@@ -62,3 +82,10 @@ def test_select_operator_uses_metric_scores() -> None:
     state.M["ineq_satisfied"] = 0.0
     chosen = select_operator(state, ops)
     assert isinstance(chosen, BaselineOp)
+
+
+def test_select_operator_breaks_ties_with_delta() -> None:
+    state = MicroState()
+    ops = [ZeroDeltaOp(), PositiveDeltaOp()]
+    chosen = select_operator(state, ops)
+    assert isinstance(chosen, PositiveDeltaOp)


### PR DESCRIPTION
## Summary
- add score() heuristic to all micro-solver operators
- make scheduler.select_operator deterministic on tie scores using delta
- test operator scoring and tie-breaking behaviour

## Testing
- `PYTHONPATH=. pytest tests/test_scheduler_metrics.py tests/test_extra_operators.py tests/test_solve_operator.py tests/test_diff_integrate_operator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b722b4048330a2a6574eac15956d