### PR TITLE
Add plan step linting to orchestrator

### DIFF
--- a/tests/test_orchestrator_plan_lint.py
+++ b/tests/test_orchestrator_plan_lint.py
@@ -1,0 +1,23 @@
+import pathlib
+import sys
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from micro_solver.orchestrator import MicroGraph, MicroRunner
+from micro_solver.state import MicroState
+
+
+def test_invalid_plan_steps_abort():
+    state = MicroState(plan_steps=[{"action": "compute", "args": {"result": 5}}])
+    runner = MicroRunner(MicroGraph([]))
+    with pytest.raises(RuntimeError) as exc:
+        runner.run(state, lint_plan=True)
+    assert "arg-forbidden:result" in str(exc.value)
+
+
+def test_lint_bypass_allows_invalid_plan():
+    state = MicroState(plan_steps=[{"action": "compute", "args": {"result": 5}}])
+    runner = MicroRunner(MicroGraph([]))
+    runner.run(state, lint_plan=False)
+

--- a/tests/test_tokenize_missing_tps.py
+++ b/tests/test_tokenize_missing_tps.py
@@ -30,7 +30,7 @@ def test_tokenize_includes_tokens_per_sentence(monkeypatch):
 
     runner = MicroRunner(MicroGraph([_micro_normalize, _micro_tokenize]))
     state = MicroState(problem_text="hello world. bye")
-    runner.run(state)
+    runner.run(state, lint_plan=False)
 
     out = captured["payload"]["out"]
     assert out["tokens_per_sentence"] == [["hello", "world"], ["bye"]]


### PR DESCRIPTION
## Summary
- Validate `MicroRunner` plan steps with `plan_policy.lint_plan`
- Allow disabling plan linting via `lint_plan` flag
- Add tests for plan linting behaviour

## Testing
- `pytest tests/test_orchestrator_plan_lint.py tests/test_tokenize_missing_tps.py`
- `pytest` *(fails: No module named 'sympy', matplotlib required)*


------
https://chatgpt.com/codex/tasks/task_e_68b6b7729aa08330b988c7422c219311