### PR TITLE
Trigger replan on unresolved degrees of freedom

### DIFF
--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -85,8 +85,15 @@ def _bounds_volume(bounds: dict[str, tuple[float | None, float | None]] | None) 
 def update_metrics(state: MicroState) -> MicroState:
     """Refresh solver metrics like degrees of freedom and progress score."""
 
+    prev_metrics = dict(getattr(state, "M", {}))
     state = _micro_monitor_dof(state)
     metrics = dict(getattr(state, "M", {}))
+
+    prev_dof = prev_metrics.get("degrees_of_freedom")
+    dof = metrics.get("degrees_of_freedom")
+    if dof is not None:
+        if dof < 0 or (prev_dof is not None and prev_dof > 0 and dof > 0):
+            metrics["needs_replan"] = True
 
     prev_res = metrics.get("residual_l2")
     res = _total_residual_l2(state)

--- a/tests/test_scheduler_replan_dof.py
+++ b/tests/test_scheduler_replan_dof.py
@@ -1,0 +1,37 @@
+from micro_solver.scheduler import update_metrics, solve
+from micro_solver.state import MicroState
+
+
+def test_under_determined_triggers_replan(monkeypatch) -> None:
+    monkeypatch.setattr("micro_solver.scheduler.random.random", lambda: 0.5)
+    state = MicroState()
+    state.V["symbolic"]["variables"] = ["x"]
+
+    state = update_metrics(state)
+    assert not state.M.get("needs_replan")
+
+    state = update_metrics(state)
+    assert state.M.get("needs_replan") is True
+
+    state.numeric_seed = 0.0
+    result = solve(state, [], max_iters=1)
+    assert result.numeric_seed == 0.5
+
+
+def test_over_determined_triggers_replan(monkeypatch) -> None:
+    monkeypatch.setattr("micro_solver.scheduler.random.random", lambda: 0.5)
+    monkeypatch.setattr(
+        "micro_solver.steps_meta.estimate_jacobian_rank",
+        lambda relations, variables: len(list(variables)) + 1,
+    )
+    state = MicroState()
+    state.V["symbolic"]["variables"] = ["x"]
+    state.C["symbolic"] = ["x = 1", "x = 2"]
+
+    state = update_metrics(state)
+    assert state.M["degrees_of_freedom"] == -1
+    assert state.M.get("needs_replan") is True
+
+    state.numeric_seed = 0.0
+    result = solve(state, [], max_iters=1)
+    assert result.numeric_seed == 0.5


### PR DESCRIPTION
## Summary
- mark `needs_replan` when degrees of freedom stay positive or go negative
- add tests ensuring under- and over-determined systems trigger replanning

## Testing
- `PYTHONPATH=. pytest tests/test_scheduler_replan_flag.py tests/test_scheduler_replan_actions.py tests/test_scheduler_metrics.py tests/test_scheduler_replan_dof.py -q`
- `PYTHONPATH=. pytest tests/test_solve_operator.py::test_solve_operator_gated_by_dof -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b76a14b88330964bc537d71d7d8b