### PR TITLE
feat: add sample operator and metrics

### DIFF
--- a/micro_solver/operators.py
+++ b/micro_solver/operators.py
@@ -583,6 +583,7 @@ DEFAULT_OPERATORS: list[Operator] = [
     TransformOperator(),
     CaseSplitOperator(),
     BoundInferOperator(),
+    FeasibleSampleOperator(),
     DomainPruneOperator(),
     NumericSolveOperator(),
     GridRefineOperator(),

--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -105,6 +105,14 @@ def update_metrics(state: MicroState) -> MicroState:
         float(prev_vol - vol) if prev_vol is not None else 0.0
     )
 
+    prev_sample = metrics.get("sample_size")
+    sample = state.V["symbolic"].get("derived", {}).get("sample")
+    sample_size = float(len(sample)) if isinstance(sample, dict) else 0.0
+    metrics["sample_size"] = sample_size
+    metrics["sample_size_reduction"] = (
+        float(prev_sample - sample_size) if prev_sample is not None else 0.0
+    )
+
     state.M = metrics
 
     metrics["progress_score"] = float(
@@ -112,6 +120,7 @@ def update_metrics(state: MicroState) -> MicroState:
         + metrics.get("residual_l2_change", 0.0)
         + metrics.get("ineq_satisfied", 0.0)
         + metrics.get("bounds_volume_reduction", 0.0)
+        + metrics.get("sample_size_reduction", 0.0)
     )
     return state
 

--- a/tests/test_extra_operators.py
+++ b/tests/test_extra_operators.py
@@ -98,9 +98,12 @@ def test_feasible_sample_operator_respects_bounds() -> None:
 def test_domain_prune_operator_removes_invalid_samples() -> None:
     state = MicroState()
     state.V["symbolic"]["variables"] = ["x", "y"]
-    state.domain = {"x": (0.0, 1.0)}
-    state.qual = {"y": {"nonnegative"}}
-    state.V["symbolic"]["derived"]["sample"] = {"x": 2.0, "y": -1.0}
+    import random
+
+    random.seed(0)
+    state, _ = FeasibleSampleOperator().apply(state)
+    state.domain = {"x": (-1.0, 0.0)}
+    state.qual = {"y": {"nonpositive"}}
     state, delta = DomainPruneOperator().apply(state)
     assert "x" not in state.V["symbolic"]["derived"]["sample"]
     assert "y" not in state.V["symbolic"]["derived"]["sample"]

--- a/tests/test_scheduler_metrics.py
+++ b/tests/test_scheduler_metrics.py
@@ -51,6 +51,20 @@ def test_update_metrics_tracks_progress() -> None:
     assert state.M["bounds_volume_reduction"] == pytest.approx(2.0)
     assert state.M["progress_score"] > p1
 
+    assert state.M["sample_size"] == pytest.approx(0.0)
+
+    state.V["symbolic"]["derived"]["sample"] = {"x": 1.0, "y": 2.0}
+    state = update_metrics(state)
+    assert state.M["sample_size"] == pytest.approx(2.0)
+    assert state.M["sample_size_reduction"] == pytest.approx(-2.0)
+    p2 = state.M["progress_score"]
+
+    state.V["symbolic"]["derived"]["sample"].pop("y")
+    state = update_metrics(state)
+    assert state.M["sample_size"] == pytest.approx(1.0)
+    assert state.M["sample_size_reduction"] == pytest.approx(1.0)
+    assert state.M["progress_score"] > p2
+
 
 def test_select_operator_uses_metric_scores() -> None:
     state = MicroState()


### PR DESCRIPTION
## Summary
- include FeasibleSampleOperator in default operator pool
- track sample statistics in scheduler progress metrics
- test DomainPruneOperator against generated samples

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b77848a0833096d63fb151a1aebe