### PR TITLE
Handle Unicode inequalities in relation parsing

### DIFF
--- a/micro_solver/steps_candidate.py
+++ b/micro_solver/steps_candidate.py
@@ -45,7 +45,7 @@ def _micro_extract_candidate(state: MicroState) -> MicroState:
     if expr is None:
         for r in reversed(state.C["symbolic"]):
             op, lhs, rhs = parse_relation_sides(r)
-            if _re.search(r"(<=|>=|!=|=|<|>)", r):
+            if _re.search(r"(<=|>=|!=|=|<|>|≤|≥)", r):
                 continue
             ok, _val = evaluate_numeric(r)
             if ok:

--- a/micro_solver/steps_meta.py
+++ b/micro_solver/steps_meta.py
@@ -8,7 +8,7 @@ stages can decide whether a replan is required.
 """
 
 from .state import MicroState
-from .sym_utils import estimate_jacobian_rank
+from .sym_utils import estimate_jacobian_rank, parse_relation_sides
 
 
 def _micro_monitor_dof(state: MicroState) -> MicroState:
@@ -26,9 +26,7 @@ def _micro_monitor_dof(state: MicroState) -> MicroState:
     eq_relations = [r for r in state.C["symbolic"] if "=" in r]
     eq_count = len(eq_relations)
     ineq_count = sum(
-        1
-        for r in state.C["symbolic"]
-        if any(op in r for op in ("<", ">", "≤", "≥")) and "=" not in r
+        1 for r in state.C["symbolic"] if parse_relation_sides(r)[0] in ("<", "<=", ">", ">=")
     )
 
     rank = estimate_jacobian_rank(eq_relations, unknowns)

--- a/tests/test_unicode_inequalities.py
+++ b/tests/test_unicode_inequalities.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from micro_solver.sym_utils import parse_relation_sides
+from micro_solver.operators import BoundInferOperator
+from micro_solver.state import MicroState
+from micro_solver.steps_meta import _micro_monitor_dof
+
+
+def test_parse_relation_sides_unicode() -> None:
+    assert parse_relation_sides("x ≤ 5") == ("<=", "x", "5")
+    assert parse_relation_sides("y ≥ 3") == (">=", "y", "3")
+
+
+def test_bound_infer_operator_unicode() -> None:
+    state = MicroState()
+    state.C["symbolic"] = ["x ≥ 0", "x ≤ 5"]
+    state, delta = BoundInferOperator().apply(state)
+    assert state.domain["x"] == (0.0, 5.0)
+    assert delta == 2
+
+
+def test_ineq_count_unicode() -> None:
+    state = MicroState()
+    state.V["symbolic"]["variables"] = ["x"]
+    state.C["symbolic"] = ["x ≥ 0", "x ≤ 5", "x = 3"]
+    state = _micro_monitor_dof(state)
+    assert state.M["ineq_count"] == 2


### PR DESCRIPTION
## Summary
- normalize Unicode ≤/≥ to <=/>= in relation parsing
- count inequalities via normalized operators for degrees-of-freedom estimates
- test Unicode inequality parsing and bound inference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b76467908330a587a5b8a06694ed