### PR TITLE
Track best candidate via residuals

### DIFF
--- a/micro_solver/certificate.py
+++ b/micro_solver/certificate.py
@@ -13,7 +13,9 @@ from .candidate import Candidate
 from .sym_utils import parse_relation_sides, _parse_expr  # type: ignore
 
 
-def _compute_residuals(relations: list[str], candidate: Any, *, varname: Optional[str] = None) -> Dict[str, float]:
+def _compute_residuals(
+    relations: list[str], candidate: Any, *, varname: Optional[str] = None
+) -> Dict[str, float]:
     """Return residuals for equality relations after substituting ``candidate``.
 
     Non-equality relations are ignored. Residuals are absolute numeric
@@ -45,14 +47,18 @@ def _compute_residuals(relations: list[str], candidate: Any, *, varname: Optiona
 def build_certificate(state: Any) -> Candidate:
     """Create a :class:`Candidate` summary for ``state``.
 
-    Uses ``state.A['symbolic']['final']`` when available, otherwise falls back to the last
-    entry in ``state.A['symbolic']['candidates']``.  The candidate always includes the
-    residuals against the original ``state.C['symbolic']`` and a ``verified`` flag
-    indicating whether the candidate passed verification.
+    Uses ``state.A['symbolic']['best']`` when available, otherwise falls back to
+    ``state.A['symbolic']['final']`` or the last entry in
+    ``state.A['symbolic']['candidates']``.  The candidate always includes the
+    residuals against the original ``state.C['symbolic']`` and a ``verified``
+    flag indicating whether the candidate passed verification.
     """
 
-    cand_val = state.A["symbolic"].get("final")
-    verified = cand_val is not None
+    cand_val = state.A["symbolic"].get("best")
+    verified = cand_val == state.A["symbolic"].get("final")
+    if cand_val is None:
+        cand_val = state.A["symbolic"].get("final")
+        verified = cand_val is not None
     if cand_val is None:
         try:
             cand_val = state.A["symbolic"]["candidates"][-1]

--- a/micro_solver/state.py
+++ b/micro_solver/state.py
@@ -66,6 +66,7 @@ class MicroState:
         default_factory=lambda: {
             rep: {
                 "candidates": [],
+                "best": None,
                 "final": None,
                 "explanation": None,
                 "intermediate": [],
@@ -102,4 +103,3 @@ class MicroState:
     error: Optional[str] = None
     skip_qa: bool = False
     next_steps: Optional[List] = None
-

--- a/tests/test_candidate_best.py
+++ b/tests/test_candidate_best.py
@@ -1,0 +1,18 @@
+from micro_solver.state import MicroState
+from micro_solver.steps_candidate import _micro_verify_sympy
+
+
+def test_best_candidate_updates() -> None:
+    state = MicroState()
+    state.V["symbolic"]["variables"] = ["x"]
+    state.C["symbolic"] = ["x + 2 = 5"]
+
+    state.A["symbolic"]["candidates"].append("2")
+    _micro_verify_sympy(state)
+    assert str(state.A["symbolic"]["best"]) == "2"
+    assert state.A["symbolic"].get("final") is None
+
+    state.A["symbolic"]["candidates"].append("3")
+    _micro_verify_sympy(state)
+    assert str(state.A["symbolic"]["best"]) == "3"
+    assert str(state.A["symbolic"].get("final")) == "3"


### PR DESCRIPTION
## Summary
- Add `best` field in solver state to track lowest residual candidate
- Update candidate verification to compute residuals and maintain `best`
- Build certificates using the best candidate and test candidate tracking

## Testing
- ⚠️ `pre-commit run --files micro_solver/state.py micro_solver/steps_candidate.py micro_solver/certificate.py tests/test_candidate_best.py` (mypy reported existing repository errors)
- ✅ `SKIP=mypy pre-commit run --files micro_solver/state.py micro_solver/steps_candidate.py micro_solver/certificate.py tests/test_candidate_best.py`
- ✅ `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b745dd808330bc2e5b1ed8c1db00