### PR TITLE
Avoid repeated sampling when sample exists

### DIFF
--- a/micro_solver/operators.py
+++ b/micro_solver/operators.py
@@ -108,7 +108,9 @@ class FeasibleSampleOperator(Operator):
     name: str = "feasible_sample"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return bool(state.V["symbolic"]["variables"])
+        return bool(state.V["symbolic"]["variables"]) and not bool(
+            state.V["symbolic"]["derived"].get("sample")
+        )
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         import random

--- a/tests/test_scheduler_defaults.py
+++ b/tests/test_scheduler_defaults.py
@@ -1,5 +1,10 @@
-from micro_solver.scheduler import solve_with_defaults
+from micro_solver.scheduler import (
+    solve_with_defaults,
+    select_operator,
+    update_metrics,
+)
 from micro_solver.state import MicroState
+from micro_solver.operators import DEFAULT_OPERATORS
 
 
 def test_default_operator_pool_solves_linear_equation() -> None:
@@ -8,3 +13,15 @@ def test_default_operator_pool_solves_linear_equation() -> None:
     state.C["symbolic"] = ["x + 2 = 5"]
     result = solve_with_defaults(state, max_iters=4)
     assert result.A["symbolic"].get("final") == "3"
+
+
+def test_sampler_inapplicable_once_sample_exists() -> None:
+    state = MicroState()
+    state.V["symbolic"]["variables"] = ["x"]
+    # Initial selection should sample since no sample exists
+    op = select_operator(update_metrics(state), DEFAULT_OPERATORS)
+    assert op and op.name == "feasible_sample"
+    state, _ = op.apply(state)
+    # After sampling, pruning should run before any resampling
+    op = select_operator(update_metrics(state), DEFAULT_OPERATORS)
+    assert op and op.name == "domain_prune"


### PR DESCRIPTION
## Summary
- Prevent `FeasibleSampleOperator` from running when a sample already exists so downstream pruning/refinement can execute
- Add regression test ensuring scheduler selects pruning after an initial sample

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6b9b9d3ac8330add02456ca680248