### PR TITLE
feat: add multi-view representation steps

### DIFF
--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -176,7 +176,13 @@ def replan(state: MicroState) -> MicroState:
             idx = state.representations.index(state.representation)
         except ValueError:
             idx = -1
-        state.representation = state.representations[(idx + 1) % len(state.representations)]
+        next_rep = state.representations[(idx + 1) % len(state.representations)]
+        if next_rep != state.representation:
+            # Swap active view containers so symbolic bucket always refers to current view
+            for bucket in ("R", "C", "V", "A"):
+                data = getattr(state, bucket)
+                data["symbolic"], data[next_rep] = data[next_rep], data["symbolic"]
+            state.representation = next_rep
 
     # Reseed numeric solver initial conditions
     state.numeric_seed = random.random()

--- a/micro_solver/steps.py
+++ b/micro_solver/steps.py
@@ -18,6 +18,8 @@ from .steps_reasoning import (
     _micro_schema,
     _micro_strategies,
 )
+from .steps_numeric import _micro_numeric
+from .steps_alt import _micro_alt
 from .steps_execution import _micro_execute_plan
 from .steps_candidate import (
     _micro_solve_sympy,
@@ -38,6 +40,8 @@ DEFAULT_MICRO_STEPS = [
     _micro_goal,
     _micro_classify,
     _micro_repr,
+    _micro_numeric,
+    _micro_alt,
     _micro_schema,
     _micro_strategies,
     _micro_execute_plan,
@@ -61,6 +65,8 @@ def build_steps(*, max_iters: Optional[int] = None) -> list:
         _micro_goal,
         _micro_classify,
         _micro_repr,
+        _micro_numeric,
+        _micro_alt,
         _micro_schema,
         _micro_strategies,
         _exec,

--- a/micro_solver/steps_alt.py
+++ b/micro_solver/steps_alt.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Populate alternative representation from existing symbolic data."""
+
+from copy import deepcopy
+
+from .state import MicroState
+
+
+def _micro_alt(state: MicroState) -> MicroState:
+    """Initialize alt view (R/C/V/A) by copying the symbolic view."""
+    try:
+        state.R["alt"] = deepcopy(state.R.get("symbolic", {}))
+        state.C["alt"] = list(state.C.get("symbolic", []))
+        state.V["alt"] = deepcopy(state.V.get("symbolic", {}))
+        state.A["alt"] = deepcopy(state.A.get("symbolic", {}))
+    except Exception as exc:  # pragma: no cover - defensive
+        state.error = f"alt-populate-failed:{exc}"
+    return state

--- a/micro_solver/steps_numeric.py
+++ b/micro_solver/steps_numeric.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Populate numeric representation from existing symbolic data."""
+
+from copy import deepcopy
+
+from .state import MicroState
+
+
+def _micro_numeric(state: MicroState) -> MicroState:
+    """Initialize numeric view (R/C/V/A) by copying the symbolic view."""
+    try:
+        state.R["numeric"] = deepcopy(state.R.get("symbolic", {}))
+        state.C["numeric"] = list(state.C.get("symbolic", []))
+        state.V["numeric"] = deepcopy(state.V.get("symbolic", {}))
+        state.A["numeric"] = deepcopy(state.A.get("symbolic", {}))
+    except Exception as exc:  # pragma: no cover - defensive
+        state.error = f"numeric-populate-failed:{exc}"
+    return state

--- a/tests/test_representation_views.py
+++ b/tests/test_representation_views.py
@@ -1,0 +1,47 @@
+from micro_solver.state import MicroState
+from micro_solver.steps_numeric import _micro_numeric
+from micro_solver.steps_alt import _micro_alt
+from micro_solver.steps import build_steps
+from micro_solver.scheduler import replan
+
+
+def test_view_population() -> None:
+    state = MicroState()
+    state.problem_text = "x = 1"
+    state.R["symbolic"]["normalized_text"] = "x = 1"
+    state.C["symbolic"] = ["x = 1"]
+    state.V["symbolic"]["variables"] = ["x"]
+
+    state = _micro_numeric(state)
+    state = _micro_alt(state)
+
+    assert state.C["numeric"] == ["x = 1"]
+    assert state.V["numeric"]["variables"] == ["x"]
+    assert state.C["alt"] == ["x = 1"]
+    assert state.V["alt"]["variables"] == ["x"]
+
+
+def test_build_steps_includes_numeric_alt_before_reasoning() -> None:
+    steps = build_steps()
+    names = [s.__name__ for s in steps]
+    n_idx = names.index("_micro_numeric")
+    a_idx = names.index("_micro_alt")
+    schema_idx = names.index("_micro_schema")
+    assert n_idx < schema_idx and a_idx < schema_idx
+
+
+def test_replan_switches_active_view_constraints_and_vars() -> None:
+    state = MicroState()
+    state.representations = ["symbolic", "numeric"]
+    state.representation = "symbolic"
+    state.C["symbolic"] = ["x = 1"]
+    state.C["numeric"] = ["x = 2"]
+    state.V["symbolic"]["variables"] = ["x"]
+    state.V["numeric"]["variables"] = ["y"]
+
+    new_state = replan(state)
+
+    assert new_state.representation == "numeric"
+    assert new_state.C["symbolic"] == ["x = 2"]
+    assert new_state.V["symbolic"]["variables"] == ["y"]
+


### PR DESCRIPTION
## Summary
- add helper steps to initialize numeric and alt problem views
- integrate new view steps into default micro solver flow
- enhance replan to swap active representation data

## Testing
- `pytest tests/test_scheduler_replan_actions.py tests/test_representation_views.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b79c8eafe883309caf7ed5927ab2fa