### PR TITLE
Track micro-solver steps in state log

### DIFF
--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -130,6 +130,15 @@ def update_metrics(state: MicroState) -> MicroState:
         + metrics.get("bounds_volume_reduction", 0.0)
         + metrics.get("sample_size_reduction", 0.0)
     )
+    try:
+        state.log.append(
+            "metrics: "
+            f"dof={metrics.get('degrees_of_freedom')} "
+            f"res={metrics.get('residual_l2')} "
+            f"score={metrics.get('progress_score')}"
+        )
+    except Exception:
+        pass
     return state
 
 
@@ -190,6 +199,12 @@ def replan(state: MicroState) -> MicroState:
         state.C["symbolic"] = list(reversed(state.C["symbolic"]))
 
     state.M["needs_replan"] = False
+    try:
+        state.log.append(
+            f"replan: rep={state.representation} case={state.active_case}"
+        )
+    except Exception:
+        pass
     return state
 
 

--- a/micro_solver/state.py
+++ b/micro_solver/state.py
@@ -103,3 +103,4 @@ class MicroState:
     error: Optional[str] = None
     skip_qa: bool = False
     next_steps: Optional[List] = None
+    log: list[str] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- add a `log` list to `MicroState`
- record metric updates and replan actions to the state log
- log each orchestrator step name and QA result in the state

## Testing
- `pre-commit run flake8 --files micro_solver/state.py micro_solver/scheduler.py micro_solver/orchestrator.py`
- `pre-commit run --files micro_solver/state.py micro_solver/scheduler.py micro_solver/orchestrator.py` *(fails: "MicroState" has no attribute "derived")*
- `pytest` *(fails: GridRefineOperator chosen over domain_prune)*

------
https://chatgpt.com/codex/tasks/task_e_68b79c9d22508330ac7b2e963a1343cc