### PR TITLE
Integrate candidate verification into scheduler

### DIFF
--- a/micro_solver/operators.py
+++ b/micro_solver/operators.py
@@ -149,7 +149,7 @@ class FeasibleSampleOperator(Operator):
                 high = 1.0
             if low >= high:
                 high = low + 1.0
-            sample[v] = random.uniform(low, high)
+            sample[v] = round(random.uniform(low, high), 3)
         state.V["symbolic"]["derived"]["sample"] = sample
         return state, 0.0
 
@@ -174,7 +174,14 @@ class SolveOperator(Operator):
         # Pick the first variable that is not yet bound in the environment.
         # When all variables are bound already, fall back to the first variable
         # so that its value can still be surfaced as a candidate answer.
-        target = next((v for v in state.V["symbolic"]["variables"] if v not in state.V["symbolic"]["env"]), None)
+        target = next(
+            (
+                v
+                for v in state.V["symbolic"]["variables"]
+                if v not in state.V["symbolic"]["env"]
+            ),
+            None,
+        )
         if target is None and state.V["symbolic"]["variables"]:
             target = state.V["symbolic"]["variables"][0]
 
@@ -194,7 +201,14 @@ class SolveOperator(Operator):
         return state, 0.0
 
     def score(self, state: MicroState) -> float:
-        target = next((v for v in state.V["symbolic"]["variables"] if v not in state.V["symbolic"]["env"]), None)
+        target = next(
+            (
+                v
+                for v in state.V["symbolic"]["variables"]
+                if v not in state.V["symbolic"]["env"]
+            ),
+            None,
+        )
         if target is None and state.V["symbolic"]["variables"]:
             target = state.V["symbolic"]["variables"][0]
         rels = _apply_env(state.C["symbolic"], state.V["symbolic"].get("env", {}))
@@ -228,7 +242,14 @@ class VerifyOperator(Operator):
             return state, 0.0
 
         # Choose the variable corresponding to the candidate: first unbound symbol
-        var = next((v for v in state.V["symbolic"]["variables"] if v not in state.V["symbolic"]["env"]), None)
+        var = next(
+            (
+                v
+                for v in state.V["symbolic"]["variables"]
+                if v not in state.V["symbolic"]["env"]
+            ),
+            None,
+        )
 
         # Substitute known bindings into the relations before verification
         rels = _apply_env(state.C["symbolic"], state.V["symbolic"]["env"])
@@ -243,7 +264,14 @@ class VerifyOperator(Operator):
             candidate = str(state.A["symbolic"]["candidates"][-1])
         except Exception:
             return 0.0
-        var = next((v for v in state.V["symbolic"]["variables"] if v not in state.V["symbolic"]["env"]), None)
+        var = next(
+            (
+                v
+                for v in state.V["symbolic"]["variables"]
+                if v not in state.V["symbolic"]["env"]
+            ),
+            None,
+        )
         rels = _apply_env(state.C["symbolic"], state.V["symbolic"]["env"])
         return 1.0 if verify_candidate(rels, candidate, varname=var) else 0.0
 
@@ -271,7 +299,9 @@ class EliminateOperator(Operator):
         delta = float(before - after)
         if delta > 0:
             state.C["symbolic"] = new_rel
-            state.V["symbolic"]["variables"] = [v for v in state.V["symbolic"]["variables"] if v != target]
+            state.V["symbolic"]["variables"] = [
+                v for v in state.V["symbolic"]["variables"] if v != target
+            ]
         return state, delta
 
     def score(self, state: MicroState) -> float:
@@ -478,8 +508,7 @@ class CaseSplitOperator(Operator):
                 L = parse_expr(lhs, transformations=trans)
                 R = parse_expr(rhs, transformations=trans)
                 if L.is_Pow and L.exp == 2 and len(L.free_symbols) == 1 and R.is_number:
-                    sym = list(L.free_symbols)[0]
-                    root = sp.sqrt(R)
+                    sp.sqrt(R)
                     return float(2)
         except Exception:
             pass
@@ -713,7 +742,10 @@ class QuadratureOperator(Operator):
     name: str = "quadrature"
 
     def applicable(self, state: MicroState) -> bool:  # pragma: no cover - trivial
-        return "integrand" in state.V["symbolic"]["derived"] and "interval" in state.V["symbolic"]["derived"]
+        return (
+            "integrand" in state.V["symbolic"]["derived"]
+            and "interval" in state.V["symbolic"]["derived"]
+        )
 
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         try:

--- a/micro_solver/orchestrator.py
+++ b/micro_solver/orchestrator.py
@@ -30,7 +30,9 @@ class MicroGraph:
 
 
 class MicroRunner:
-    def __init__(self, graph: MicroGraph, *, verbose: bool = False, qa_max_retries: int = 5) -> None:
+    def __init__(
+        self, graph: MicroGraph, *, verbose: bool = False, qa_max_retries: int = 5
+    ) -> None:
         self.graph = graph
         self.verbose = verbose
         self.qa_max_retries = qa_max_retries
@@ -38,7 +40,9 @@ class MicroRunner:
         self.logger = logging.getLogger("micro_solver.orchestrator")
         self.logger.setLevel(logging.INFO if verbose else logging.WARNING)
 
-    def _qa(self, step_name: str, before: MicroState, after: MicroState, out_obj: Any) -> tuple[bool, str]:  # noqa: ANN401 - generic
+    def _qa(
+        self, step_name: str, before: MicroState, after: MicroState, out_obj: Any
+    ) -> tuple[bool, str]:  # noqa: ANN401 - generic
         # (Legacy static-plan prechecks removed; dynamic atomic planning is used.)
         try:
             payload = json.dumps({
@@ -94,7 +98,10 @@ class MicroRunner:
                 state.error = err
                 raise RuntimeError(err)
         # Step-specific minimal outputs for QA
-        def _build_step_out(step_name: str, before: MicroState, after: MicroState) -> dict[str, Any]:  # noqa: ANN401 - generic
+
+        def _build_step_out(
+            step_name: str, before: MicroState, after: MicroState
+        ) -> dict[str, Any]:  # noqa: ANN401 - generic
             try:
                 if step_name == "tokenize":
                     return {
@@ -127,15 +134,8 @@ class MicroRunner:
                         "relations": after.C["symbolic"],
                         "progress_score": after.M.get("progress_score"),
                         "degrees_of_freedom": after.M.get("degrees_of_freedom"),
+                        "final_answer": after.A["symbolic"].get("final"),
                     }
-                if step_name == "extract_candidate":
-                    last = after.A["symbolic"]["candidates"][-1] if after.A["symbolic"]["candidates"] else None
-                    return {"candidate": last}
-                if step_name == "simplify_candidate_sympy":
-                    last = after.A["symbolic"]["candidates"][-1] if after.A["symbolic"]["candidates"] else None
-                    return {"candidate_simplified": last}
-                if step_name in {"verify_sympy", "verify"}:
-                    return {"final_answer": after.A["symbolic"].get("final")}
             except Exception:
                 pass
             # Fallback: generic delta
@@ -158,10 +158,15 @@ class MicroRunner:
                 if step_name == "normalize":
                     return f"normalized_len={len(after.R['symbolic'].get('normalized_text') or '')}"
                 if step_name == "tokenize":
-                    return f"sentences={len(after.R['symbolic'].get('sentences') or [])} tokens={len(after.R['symbolic'].get('tokens') or [])}"
+                    return (
+                        f"sentences={len(after.R['symbolic'].get('sentences') or [])} "
+                        f"tokens={len(after.R['symbolic'].get('tokens') or [])}"
+                    )
                 if step_name == "entities":
                     return (
-                        f"vars={len(after.V['symbolic'].get('variables') or [])} consts={len(after.V['symbolic'].get('constants') or [])} qty={len(after.V['symbolic'].get('quantities') or [])}"
+                        f"vars={len(after.V['symbolic'].get('variables') or [])} "
+                        f"consts={len(after.V['symbolic'].get('constants') or [])} "
+                        f"qty={len(after.V['symbolic'].get('quantities') or [])}"
                     )
                 if step_name == "relations":
                     head = _trunc(after.C["symbolic"][0]) if after.C["symbolic"] else ""
@@ -205,15 +210,12 @@ class MicroRunner:
                         tail += f" score={after.M.get('progress_score')}"
                     except Exception:
                         pass
+                    try:
+                        if after.A["symbolic"].get("final") is not None:
+                            tail += f" final='{_trunc(after.A['symbolic'].get('final'))}'"
+                    except Exception:
+                        pass
                     return base + tail
-                if step_name == "extract_candidate":
-                    cand = after.A["symbolic"]["candidates"][-1] if after.A["symbolic"]["candidates"] else None
-                    return f"candidate='{_trunc(cand)}'"
-                if step_name == "simplify_candidate_sympy":
-                    cand = after.A["symbolic"]["candidates"][-1] if after.A["symbolic"]["candidates"] else None
-                    return f"simplified='{_trunc(cand)}'"
-                if step_name in {"verify_sympy", "verify"}:
-                    return f"final='{_trunc(after.A["symbolic"].get("final"))}'"
             except Exception:
                 return ""
             return ""
@@ -304,7 +306,11 @@ class MicroRunner:
             # 1) If we have candidates, surface the last one as an unverified fallback
             fallback_msg = None
             try:
-                last_cand = state.A["symbolic"]["candidates"][-1] if state.A["symbolic"]["candidates"] else None
+                last_cand = (
+                    state.A["symbolic"]["candidates"][-1]
+                    if state.A["symbolic"]["candidates"]
+                    else None
+                )
             except Exception:
                 last_cand = None
             if last_cand is not None:

--- a/micro_solver/steps.py
+++ b/micro_solver/steps.py
@@ -19,12 +19,6 @@ from .steps_reasoning import (
     _micro_strategies,
 )
 from .steps_execution import _micro_execute_plan
-from .steps_candidate import (
-    _micro_solve_sympy,
-    _micro_extract_candidate,
-    _micro_simplify_candidate_sympy,
-    _micro_verify_sympy,
-)
 from .steps_meta import _micro_monitor_dof
 
 
@@ -65,8 +59,4 @@ def build_steps(*, max_iters: Optional[int] = None) -> list:
         _micro_strategies,
         _exec,
         _micro_monitor_dof,
-        _micro_solve_sympy,
-        _micro_extract_candidate,
-        _micro_simplify_candidate_sympy,
-        _micro_verify_sympy,
     ]


### PR DESCRIPTION
## Summary
- seed initial answer candidates from the environment before scheduling
- remove candidate extraction/simplification/verification steps and surface final answers directly from scheduler
- propagate final answers through orchestrator and round feasible samples for stable operator ordering

## Testing
- `pytest`
- `pre-commit run --files micro_solver/scheduler.py micro_solver/steps.py micro_solver/orchestrator.py micro_solver/operators.py` *(fails: mypy found existing type issues across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b79cbd072483308fbf7151519a3f09