### PR TITLE
Fix representation swap when replanning

### DIFF
--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -176,12 +176,13 @@ def replan(state: MicroState) -> MicroState:
             idx = state.representations.index(state.representation)
         except ValueError:
             idx = -1
+        curr_rep = state.representation
         next_rep = state.representations[(idx + 1) % len(state.representations)]
-        if next_rep != state.representation:
+        if next_rep != curr_rep:
             # Swap active view containers so symbolic bucket always refers to current view
             for bucket in ("R", "C", "V", "A"):
                 data = getattr(state, bucket)
-                data["symbolic"], data[next_rep] = data[next_rep], data["symbolic"]
+                data[curr_rep], data[next_rep] = data[next_rep], data[curr_rep]
             state.representation = next_rep
 
     # Reseed numeric solver initial conditions


### PR DESCRIPTION
## Summary
- Ensure replan swaps view containers using the current representation key

## Testing
- `pre-commit run --files micro_solver/scheduler.py` *(fails: mypy with many errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sympy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a25a3e1c8330ad21a6ccfafeefdd