### PR TITLE
Fix redundant constraint removal and deterministic sampling

### DIFF
--- a/micro_solver/operators.py
+++ b/micro_solver/operators.py
@@ -129,6 +129,7 @@ class FeasibleSampleOperator(Operator):
     def apply(self, state: MicroState) -> Tuple[MicroState, float]:
         import random
 
+        random.seed(state.numeric_seed)
         sample: dict[str, float] = {}
         for v in state.V["symbolic"]["variables"]:
             low, high = state.domain.get(v, (None, None))
@@ -149,7 +150,8 @@ class FeasibleSampleOperator(Operator):
                 high = 1.0
             if low >= high:
                 high = low + 1.0
-            sample[v] = random.uniform(low, high)
+            val = random.uniform(low, high)
+            sample[v] = round(val, 3)
         state.V["symbolic"]["derived"]["sample"] = sample
         return state, 0.0
 

--- a/micro_solver/scheduler.py
+++ b/micro_solver/scheduler.py
@@ -88,11 +88,13 @@ def update_metrics(state: MicroState) -> MicroState:
 
     prev_metrics = dict(getattr(state, "M", {}))
     state = _micro_monitor_dof(state)
-    redundant = list(state.M.get("redundant_constraints", []))
-    if redundant:
-        state.C["symbolic"] = [r for r in state.C["symbolic"] if r not in redundant]
+    redundant_idx = list(state.M.get("redundant_constraints_idx", []))
+    if redundant_idx:
+        removed = [r for i, r in enumerate(state.C["symbolic"]) if i in redundant_idx]
+        state.C["symbolic"] = [r for i, r in enumerate(state.C["symbolic"]) if i not in redundant_idx]
         state = _micro_monitor_dof(state)
-        state.M["redundant_constraints"] = redundant
+        state.M["redundant_constraints_idx"] = redundant_idx
+        state.M["redundant_constraints"] = removed
     metrics = dict(getattr(state, "M", {}))
 
     prev_dof = prev_metrics.get("degrees_of_freedom")

--- a/micro_solver/steps_meta.py
+++ b/micro_solver/steps_meta.py
@@ -30,9 +30,10 @@ def _micro_monitor_dof(state: MicroState) -> MicroState:
         1 for r in state.C["symbolic"] if parse_relation_sides(r)[0] in ("<", "<=", ">", ">=")
     )
 
-    independence = build_independence_graph(eq_relations, unknowns)
+    independence = build_independence_graph(state.C["symbolic"], unknowns)
     redundant_idx = independence.get("redundant", [])
-    state.M["redundant_constraints"] = [eq_relations[i] for i in redundant_idx]
+    state.M["redundant_constraints_idx"] = redundant_idx
+    state.M["redundant_constraints"] = [state.C["symbolic"][i] for i in redundant_idx]
     state.M["independence_graph"] = independence.get("graph", {})
 
     rank = estimate_jacobian_rank(eq_relations, unknowns)

--- a/tests/test_constraint_analysis.py
+++ b/tests/test_constraint_analysis.py
@@ -40,4 +40,5 @@ def test_monitor_dof_records_redundant() -> None:
     state.V["symbolic"]["variables"] = ["x", "y"]
     state.C["symbolic"] = ["x + y = 2", "2x + 2y = 4", "x - y = 0"]
     state = _micro_monitor_dof(state)
+    assert state.M["redundant_constraints_idx"] == [1]
     assert state.M["redundant_constraints"] == ["2x + 2y = 4"]

--- a/tests/test_scheduler_metrics.py
+++ b/tests/test_scheduler_metrics.py
@@ -111,4 +111,5 @@ def test_update_metrics_drops_redundant_relations() -> None:
     state.C["symbolic"] = ["x + y = 2", "2x + 2y = 4", "x - y = 0"]
     state = update_metrics(state)
     assert "2x + 2y = 4" not in state.C["symbolic"]
+    assert state.M["redundant_constraints_idx"] == [1]
     assert state.M["redundant_constraints"] == ["2x + 2y = 4"]


### PR DESCRIPTION
## Summary
- Track redundant constraints by index and remove them accordingly
- Make numeric sampling deterministic and pre-rounded to avoid unnecessary grid refinement
- Update tests for index-based constraint tracking

## Testing
- `pip install -r requirements-dev.txt`
- `pip install matplotlib`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a2983dd083309003c42720f96a77