### PR TITLE
Handle multi-part goals in micro-solver

### DIFF
--- a/tests/test_scheduler_goal_decomposition.py
+++ b/tests/test_scheduler_goal_decomposition.py
@@ -1,0 +1,13 @@
+from micro_solver.scheduler import replan
+from micro_solver.state import MicroState
+
+
+def test_replan_decomposes_multi_goal() -> None:
+    state = MicroState(goal="solve for x and y")
+    state.representations = ["symbolic"]
+    new_state = replan(state)
+    assert new_state.goal == ["solve for x", "solve for y"]
+    assert new_state.plan_steps == [
+        {"action": "subgoal", "goal": "solve for x"},
+        {"action": "subgoal", "goal": "solve for y"},
+    ]

--- a/tests/test_steps_reasoning_subgoals.py
+++ b/tests/test_steps_reasoning_subgoals.py
@@ -1,0 +1,24 @@
+from micro_solver.state import MicroState
+import micro_solver.steps_reasoning as SR
+
+
+def test_micro_schema_handles_list_goal(monkeypatch) -> None:
+    state = MicroState(goal=["g1", "g2"])
+
+    def fake_invoke(agent, payload, qa_feedback=None, **kwargs):
+        return {"schemas": [payload["target"] + "_schema"]}, None
+
+    monkeypatch.setattr(SR, "_invoke", fake_invoke)
+    new_state = SR._micro_schema(state)
+    assert new_state.schemas == ["g1_schema", "g2_schema"]
+
+
+def test_micro_strategies_handles_list_goal(monkeypatch) -> None:
+    state = MicroState(goal=["g1", "g2"], schemas=["s"])
+
+    def fake_invoke(agent, payload, qa_feedback=None, **kwargs):
+        return {"strategies": [payload["target"] + "_strategy"]}, None
+
+    monkeypatch.setattr(SR, "_invoke", fake_invoke)
+    new_state = SR._micro_strategies(state)
+    assert new_state.strategies == ["g1_strategy", "g2_strategy"]


### PR DESCRIPTION
## Summary
- add `decompose_goal` helper to split multi-part goals and initialize subgoal plan steps
- invoke goal decomposition within `replan`
- allow reasoning steps `_micro_schema` and `_micro_strategies` to accept lists of subgoals
- add tests for goal decomposition and list-aware reasoning

## Testing
- `PYTHONPATH=. pytest tests/test_scheduler_goal_decomposition.py tests/test_steps_reasoning_subgoals.py tests/test_scheduler_replan_actions.py tests/test_scheduler_replan_flag.py tests/test_scheduler_replan_dof.py tests/test_scheduler_defaults.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7ac3e3d048330a7e72c768aada671